### PR TITLE
Add files via upload

### DIFF
--- a/xapp1292-loading-partial-bitstreams-using-tftp/common/Sources/xdc/top.xdc
+++ b/xapp1292-loading-partial-bitstreams-using-tftp/common/Sources/xdc/top.xdc
@@ -25,46 +25,56 @@
 #-----------------------------------
 # ICAPE2 constraints
 #-----------------------------------
-set icap_clock       [get_clocks -of_objects [get_ports ICAPE2_inst/CLK]]
+# set icap_clock       [get_clocks -of_objects [get_ports ICAPE2_inst/CLK]]
+set icap_clock       [get_clocks -of_objects [get_ports ICAPE3_inst/CLK]]
+
+
+#-----------------------------------
+# ICAPE3 constraints
+#-----------------------------------
+set_property PACKAGE_PIN BM29 [get_ports reset]
+set_property IOSTANDARD LVCMOS12 [get_ports reset]
+
 
 #-----------------------------------
 # LED LOCs
 #-----------------------------------
 #    LED[0-3] shift
 #    LED[4-7] count
-#-----------------------------------
+#-----------------------------------VCU128 LEDs :
 #LED0
-set_property PACKAGE_PIN AB8     [get_ports shift_out[0]]
-set_property IOSTANDARD LVCMOS15 [get_ports shift_out[0]]
+set_property PACKAGE_PIN BH24     [get_ports shift_out[0]]
+set_property IOSTANDARD LVCMOS18 [get_ports shift_out[0]]
 
 # LED1
-set_property PACKAGE_PIN AA8     [get_ports shift_out[1]]
-set_property IOSTANDARD LVCMOS15 [get_ports shift_out[1]]
+set_property PACKAGE_PIN BG24     [get_ports shift_out[1]]
+set_property IOSTANDARD LVCMOS18 [get_ports shift_out[1]]
 
 # LED2
-set_property PACKAGE_PIN AC9     [get_ports shift_out[2]]
-set_property IOSTANDARD LVCMOS15 [get_ports shift_out[2]]
+set_property PACKAGE_PIN BG25     [get_ports shift_out[2]]
+set_property IOSTANDARD LVCMOS18 [get_ports shift_out[2]]
 
 # LED3
-set_property PACKAGE_PIN AB9     [get_ports shift_out[3]]
-set_property IOSTANDARD LVCMOS15 [get_ports shift_out[3]]
+set_property PACKAGE_PIN BF25     [get_ports shift_out[3]]
+set_property IOSTANDARD LVCMOS18 [get_ports shift_out[3]]
 
 # LED4
-set_property PACKAGE_PIN AE26    [get_ports count_out[0]]
-set_property IOSTANDARD LVCMOS25 [get_ports count_out[0]]
+set_property PACKAGE_PIN BF26    [get_ports count_out[0]]
+set_property IOSTANDARD LVCMOS18 [get_ports count_out[0]]
 
 # LED5
-set_property PACKAGE_PIN G19     [get_ports count_out[1]]
-set_property IOSTANDARD LVCMOS25 [get_ports count_out[1]]
+set_property PACKAGE_PIN BF27     [get_ports count_out[1]]
+set_property IOSTANDARD LVCMOS18 [get_ports count_out[1]]
 
 # LED6
-set_property PACKAGE_PIN E18     [get_ports count_out[2]]
-set_property IOSTANDARD LVCMOS25 [get_ports count_out[2]]
+set_property PACKAGE_PIN BG27     [get_ports count_out[2]]
+set_property IOSTANDARD LVCMOS18 [get_ports count_out[2]]
 
 # LED7
-set_property PACKAGE_PIN F16     [get_ports count_out[3]]
-set_property IOSTANDARD LVCMOS25 [get_ports count_out[3]]
+set_property PACKAGE_PIN BG28     [get_ports count_out[3]]
+set_property IOSTANDARD LVCMOS18 [get_ports count_out[3]]
 
+#################################################################################
 
 #-------------------------------------------------
 # pblock_count 

--- a/xapp1292-loading-partial-bitstreams-using-tftp/common/set_part.tcl
+++ b/xapp1292-loading-partial-bitstreams-using-tftp/common/set_part.tcl
@@ -1,5 +1,6 @@
-# Set the part number to target.  Used by design.tcl and gen_ip.tcl
-#
-set part  xc7k325tffg900-2
+# set part  xc7k325tffg900-2
+set part  xcvu37p-fsvh2892-2L-e
 
-set board xilinx.com:kc705:part0:1.2
+# set board xilinx.com:kc705:part0:1.2
+set board xilinx.com:vcu128:part0:1.0
+# set_property board_part xilinx.com:vcu128:part0:1.0

--- a/xapp1292-loading-partial-bitstreams-using-tftp/example_3/Sources/hdl/top/top.vhd
+++ b/xapp1292-loading-partial-bitstreams-using-tftp/example_3/Sources/hdl/top/top.vhd
@@ -14,48 +14,76 @@ entity top is
   port(
     -- Clocks
     --
-    clk_p     : in  std_logic;                     -- 200MHz differential input clock
-    clk_n     : in  std_logic;                     -- 200MHz differential input clock
-    reset     : in std_logic;
+    -- clk_p     : in  std_logic;                     -- 200MHz differential input clock
+    -- clk_n     : in  std_logic;                     -- 200MHz differential input clock
+    -- reset     : in std_logic;
     count_out : out std_logic_vector(3 downto 0);  -- mapped to general purpose LEDs[4-7]
     shift_out : out std_logic_vector(3 downto 0);  -- mapped to general purpose LEDs[0-3]
 
-    -- DDR3 Memory
-    --
-    ddr3_sdram_addr : out STD_LOGIC_VECTOR ( 13 downto 0 );
-    ddr3_sdram_ba : out STD_LOGIC_VECTOR ( 2 downto 0 );
-    ddr3_sdram_cas_n : out STD_LOGIC;
-    ddr3_sdram_ck_n : out STD_LOGIC_VECTOR ( 0 to 0 );
-    ddr3_sdram_ck_p : out STD_LOGIC_VECTOR ( 0 to 0 );
-    ddr3_sdram_cke : out STD_LOGIC_VECTOR ( 0 to 0 );
-    ddr3_sdram_cs_n : out STD_LOGIC_VECTOR ( 0 to 0 );
-    ddr3_sdram_dm : out STD_LOGIC_VECTOR ( 7 downto 0 );
-    ddr3_sdram_dq : inout STD_LOGIC_VECTOR ( 63 downto 0 );
-    ddr3_sdram_dqs_n : inout STD_LOGIC_VECTOR ( 7 downto 0 );
-    ddr3_sdram_dqs_p : inout STD_LOGIC_VECTOR ( 7 downto 0 );
-    ddr3_sdram_odt : out STD_LOGIC_VECTOR ( 0 to 0 );
-    ddr3_sdram_ras_n : out STD_LOGIC;
-    ddr3_sdram_reset_n : out STD_LOGIC;
-    ddr3_sdram_we_n : out STD_LOGIC;
+    -- -- DDR3 Memory
+    -- --
+    -- ddr3_sdram_addr : out STD_LOGIC_VECTOR ( 13 downto 0 );
+    -- ddr3_sdram_ba : out STD_LOGIC_VECTOR ( 2 downto 0 );
+    -- ddr3_sdram_cas_n : out STD_LOGIC;
+    -- ddr3_sdram_ck_n : out STD_LOGIC_VECTOR ( 0 to 0 );
+    -- ddr3_sdram_ck_p : out STD_LOGIC_VECTOR ( 0 to 0 );
+    -- ddr3_sdram_cke : out STD_LOGIC_VECTOR ( 0 to 0 );
+    -- ddr3_sdram_cs_n : out STD_LOGIC_VECTOR ( 0 to 0 );
+    -- ddr3_sdram_dm : out STD_LOGIC_VECTOR ( 7 downto 0 );
+    -- ddr3_sdram_dq : inout STD_LOGIC_VECTOR ( 63 downto 0 );
+    -- ddr3_sdram_dqs_n : inout STD_LOGIC_VECTOR ( 7 downto 0 );
+    -- ddr3_sdram_dqs_p : inout STD_LOGIC_VECTOR ( 7 downto 0 );
+    -- ddr3_sdram_odt : out STD_LOGIC_VECTOR ( 0 to 0 );
+    -- ddr3_sdram_ras_n : out STD_LOGIC;
+    -- ddr3_sdram_reset_n : out STD_LOGIC;
+    -- ddr3_sdram_we_n : out STD_LOGIC;
 
-    -- Ethernet
+    -- -- Ethernet
+    -- mdio_mdc_mdc : out STD_LOGIC;
+    -- mdio_mdc_mdio_io : inout STD_LOGIC;
+    -- mii_col : in STD_LOGIC;
+    -- mii_crs : in STD_LOGIC;
+    -- mii_rst_n : out STD_LOGIC;
+    -- mii_rx_clk : in STD_LOGIC;
+    -- mii_rx_dv : in STD_LOGIC;
+    -- mii_rx_er : in STD_LOGIC;
+    -- mii_rxd : in STD_LOGIC_VECTOR ( 3 downto 0 );
+    -- mii_tx_clk : in STD_LOGIC;
+    -- mii_tx_en : out STD_LOGIC;
+    -- mii_txd : out STD_LOGIC_VECTOR ( 3 downto 0 );
+   
+    -- -- UART
+    -- rs232_uart_rxd : in STD_LOGIC;
+    -- rs232_uart_txd : out STD_LOGIC
+
+    ddr4_sdram_act_n : out STD_LOGIC;
+    ddr4_sdram_adr : out STD_LOGIC_VECTOR ( 16 downto 0 );
+    ddr4_sdram_ba : out STD_LOGIC_VECTOR ( 1 downto 0 );
+    ddr4_sdram_bg : out STD_LOGIC;
+    ddr4_sdram_ck_c : out STD_LOGIC;
+    ddr4_sdram_ck_t : out STD_LOGIC;
+    ddr4_sdram_cke : out STD_LOGIC;
+    ddr4_sdram_cs_n : out STD_LOGIC_VECTOR ( 1 downto 0 );
+    ddr4_sdram_dm_n : inout STD_LOGIC_VECTOR ( 8 downto 0 );
+    ddr4_sdram_dq : inout STD_LOGIC_VECTOR ( 71 downto 0 );
+    ddr4_sdram_dqs_c : inout STD_LOGIC_VECTOR ( 8 downto 0 );
+    ddr4_sdram_dqs_t : inout STD_LOGIC_VECTOR ( 8 downto 0 );
+    ddr4_sdram_odt : out STD_LOGIC;
+    ddr4_sdram_reset_n : out STD_LOGIC;
+    default_100mhz_clk_clk_n : in STD_LOGIC;
+    default_100mhz_clk_clk_p : in STD_LOGIC;
+    dummy_port_in : in STD_LOGIC;
     mdio_mdc_mdc : out STD_LOGIC;
     mdio_mdc_mdio_io : inout STD_LOGIC;
-    mii_col : in STD_LOGIC;
-    mii_crs : in STD_LOGIC;
-    mii_rst_n : out STD_LOGIC;
-    mii_rx_clk : in STD_LOGIC;
-    mii_rx_dv : in STD_LOGIC;
-    mii_rx_er : in STD_LOGIC;
-    mii_rxd : in STD_LOGIC_VECTOR ( 3 downto 0 );
-    mii_tx_clk : in STD_LOGIC;
-    mii_tx_en : out STD_LOGIC;
-    mii_txd : out STD_LOGIC_VECTOR ( 3 downto 0 );
-   
-    -- UART
-    rs232_uart_rxd : in STD_LOGIC;
-    rs232_uart_txd : out STD_LOGIC
-    
+    reset : in STD_LOGIC;
+    rs232_uart_0_rxd : in STD_LOGIC;
+    rs232_uart_0_txd : out STD_LOGIC;
+    sgmii_lvds_rxn : in STD_LOGIC;
+    sgmii_lvds_rxp : in STD_LOGIC;
+    sgmii_lvds_txn : out STD_LOGIC;
+    sgmii_lvds_txp : out STD_LOGIC;
+    sgmii_phyclk_clk_n : in STD_LOGIC;
+    sgmii_phyclk_clk_p : in STD_LOGIC
     );
 end top;
 
@@ -63,43 +91,80 @@ architecture rtl of top is
 
   component static_bd_wrapper
     port (
-      ICAP_csib : out STD_LOGIC;
-      ICAP_rdwrb : out STD_LOGIC;
-      clk_100 : out STD_LOGIC;
-      ddr3_sdram_addr : out STD_LOGIC_VECTOR ( 13 downto 0 );
-      ddr3_sdram_ba : out STD_LOGIC_VECTOR ( 2 downto 0 );
-      ddr3_sdram_cas_n : out STD_LOGIC;
-      ddr3_sdram_ck_n : out STD_LOGIC_VECTOR ( 0 to 0 );
-      ddr3_sdram_ck_p : out STD_LOGIC_VECTOR ( 0 to 0 );
-      ddr3_sdram_cke : out STD_LOGIC_VECTOR ( 0 to 0 );
-      ddr3_sdram_cs_n : out STD_LOGIC_VECTOR ( 0 to 0 );
-      ddr3_sdram_dm : out STD_LOGIC_VECTOR ( 7 downto 0 );
-      ddr3_sdram_dq : inout STD_LOGIC_VECTOR ( 63 downto 0 );
-      ddr3_sdram_dqs_n : inout STD_LOGIC_VECTOR ( 7 downto 0 );
-      ddr3_sdram_dqs_p : inout STD_LOGIC_VECTOR ( 7 downto 0 );
-      ddr3_sdram_odt : out STD_LOGIC_VECTOR ( 0 to 0 );
-      ddr3_sdram_ras_n : out STD_LOGIC;
-      ddr3_sdram_reset_n : out STD_LOGIC;
-      ddr3_sdram_we_n : out STD_LOGIC;
-      icap_i : out STD_LOGIC_VECTOR ( 31 downto 0 );
-      icap_o : in STD_LOGIC_VECTOR ( 31 downto 0 );
+      -- ICAP_csib : out STD_LOGIC;
+      -- ICAP_rdwrb : out STD_LOGIC;
+      -- clk_100 : out STD_LOGIC;
+      -- ddr3_sdram_addr : out STD_LOGIC_VECTOR ( 13 downto 0 );
+      -- ddr3_sdram_ba : out STD_LOGIC_VECTOR ( 2 downto 0 );
+      -- ddr3_sdram_cas_n : out STD_LOGIC;
+      -- ddr3_sdram_ck_n : out STD_LOGIC_VECTOR ( 0 to 0 );
+      -- ddr3_sdram_ck_p : out STD_LOGIC_VECTOR ( 0 to 0 );
+      -- ddr3_sdram_cke : out STD_LOGIC_VECTOR ( 0 to 0 );
+      -- ddr3_sdram_cs_n : out STD_LOGIC_VECTOR ( 0 to 0 );
+      -- ddr3_sdram_dm : out STD_LOGIC_VECTOR ( 7 downto 0 );
+      -- ddr3_sdram_dq : inout STD_LOGIC_VECTOR ( 63 downto 0 );
+      -- ddr3_sdram_dqs_n : inout STD_LOGIC_VECTOR ( 7 downto 0 );
+      -- ddr3_sdram_dqs_p : inout STD_LOGIC_VECTOR ( 7 downto 0 );
+      -- ddr3_sdram_odt : out STD_LOGIC_VECTOR ( 0 to 0 );
+      -- ddr3_sdram_ras_n : out STD_LOGIC;
+      -- ddr3_sdram_reset_n : out STD_LOGIC;
+      -- ddr3_sdram_we_n : out STD_LOGIC;
+      -- icap_i : out STD_LOGIC_VECTOR ( 31 downto 0 );
+      -- icap_o : in STD_LOGIC_VECTOR ( 31 downto 0 );
+      -- mdio_mdc_mdc : out STD_LOGIC;
+      -- mdio_mdc_mdio_io : inout STD_LOGIC;
+      -- mii_col : in STD_LOGIC;
+      -- mii_crs : in STD_LOGIC;
+      -- mii_rst_n : out STD_LOGIC;
+      -- mii_rx_clk : in STD_LOGIC;
+      -- mii_rx_dv : in STD_LOGIC;
+      -- mii_rx_er : in STD_LOGIC;
+      -- mii_rxd : in STD_LOGIC_VECTOR ( 3 downto 0 );
+      -- mii_tx_clk : in STD_LOGIC;
+      -- mii_tx_en : out STD_LOGIC;
+      -- mii_txd : out STD_LOGIC_VECTOR ( 3 downto 0 );
+      -- reset : in STD_LOGIC;
+      -- rs232_uart_rxd : in STD_LOGIC;
+      -- rs232_uart_txd : out STD_LOGIC;
+      -- sys_diff_clock_clk_n : in STD_LOGIC;
+      -- sys_diff_clock_clk_p : in STD_LOGIC
+      
+      ICAP_0_avail : in STD_LOGIC;
+      ICAP_0_csib : out STD_LOGIC;
+      ICAP_0_i : out STD_LOGIC_VECTOR ( 31 downto 0 );
+      ICAP_0_o : in STD_LOGIC_VECTOR ( 31 downto 0 );
+      ICAP_0_rdwrb : out STD_LOGIC;
+      addn_ui_clkout3_0 : out STD_LOGIC;
+      ddr4_sdram_act_n : out STD_LOGIC;
+      ddr4_sdram_adr : out STD_LOGIC_VECTOR ( 16 downto 0 );
+      ddr4_sdram_ba : out STD_LOGIC_VECTOR ( 1 downto 0 );
+      ddr4_sdram_bg : out STD_LOGIC;
+      ddr4_sdram_ck_c : out STD_LOGIC;
+      ddr4_sdram_ck_t : out STD_LOGIC;
+      ddr4_sdram_cke : out STD_LOGIC;
+      ddr4_sdram_cs_n : out STD_LOGIC_VECTOR ( 1 downto 0 );
+      ddr4_sdram_dm_n : inout STD_LOGIC_VECTOR ( 8 downto 0 );
+      ddr4_sdram_dq : inout STD_LOGIC_VECTOR ( 71 downto 0 );
+      ddr4_sdram_dqs_c : inout STD_LOGIC_VECTOR ( 8 downto 0 );
+      ddr4_sdram_dqs_t : inout STD_LOGIC_VECTOR ( 8 downto 0 );
+      ddr4_sdram_odt : out STD_LOGIC;
+      ddr4_sdram_reset_n : out STD_LOGIC;
+      default_100mhz_clk_clk_n : in STD_LOGIC;
+      default_100mhz_clk_clk_p : in STD_LOGIC;
+      dummy_port_in : in STD_LOGIC;
       mdio_mdc_mdc : out STD_LOGIC;
       mdio_mdc_mdio_io : inout STD_LOGIC;
-      mii_col : in STD_LOGIC;
-      mii_crs : in STD_LOGIC;
-      mii_rst_n : out STD_LOGIC;
-      mii_rx_clk : in STD_LOGIC;
-      mii_rx_dv : in STD_LOGIC;
-      mii_rx_er : in STD_LOGIC;
-      mii_rxd : in STD_LOGIC_VECTOR ( 3 downto 0 );
-      mii_tx_clk : in STD_LOGIC;
-      mii_tx_en : out STD_LOGIC;
-      mii_txd : out STD_LOGIC_VECTOR ( 3 downto 0 );
       reset : in STD_LOGIC;
-      rs232_uart_rxd : in STD_LOGIC;
-      rs232_uart_txd : out STD_LOGIC;
-      sys_diff_clock_clk_n : in STD_LOGIC;
-      sys_diff_clock_clk_p : in STD_LOGIC);
+      rs232_uart_0_rxd : in STD_LOGIC;
+      rs232_uart_0_txd : out STD_LOGIC;
+      sgmii_lvds_rxn : in STD_LOGIC;
+      sgmii_lvds_rxp : in STD_LOGIC;
+      sgmii_lvds_txn : out STD_LOGIC;
+      sgmii_lvds_txp : out STD_LOGIC;
+      sgmii_phyclk_clk_n : in STD_LOGIC;
+      sgmii_phyclk_clk_p : in STD_LOGIC 
+
+      );
   end component;
 
   
@@ -107,7 +172,7 @@ architecture rtl of top is
   -- -------------------------------------------------------------------------
   -- System signals
   -- -------------------------------------------------------------------------
-  signal clk_100   : std_logic;         -- 100 MHz clock
+  signal addn_ui_clkout3_0   : std_logic;         -- 100 MHz clock
 
   constant C_ICAP_DATA_WIDTH : integer := 32;
 
@@ -116,10 +181,12 @@ architecture rtl of top is
   -- ------------------------------------------------------------------------
 
   -- The ICAP interace signals
-  signal icap_i     : std_logic_vector(C_ICAP_DATA_WIDTH-1 downto 0); 
-  signal icap_o     : std_logic_vector(C_ICAP_DATA_WIDTH-1 downto 0); 
-  signal icap_csib  : std_logic;
-  signal icap_rdwrb : std_logic;
+  signal icap_0_i     : std_logic_vector(C_ICAP_DATA_WIDTH-1 downto 0); 
+  signal icap_0_o     : std_logic_vector(C_ICAP_DATA_WIDTH-1 downto 0); 
+  signal icap_0_csib  : std_logic;
+  signal icap_0_rdwrb : std_logic;
+
+  signal ICAP_0_avail : std_logic;
 
   signal count_value      : std_logic_vector(34 downto 0);
 
@@ -159,50 +226,80 @@ begin
     port map (
       -- Clocks and reset
       reset                => reset,
-      sys_diff_clock_clk_n => clk_n,
-      sys_diff_clock_clk_p => clk_p,
-      clk_100              => clk_100,
+      -- sys_diff_clock_clk_n => clk_n,
+      -- sys_diff_clock_clk_p => clk_p,
+      default_100mhz_clk_clk_n => default_100mhz_clk_clk_n,
+      default_100mhz_clk_clk_p => default_100mhz_clk_clk_p,
+
+      addn_ui_clkout3_0              => addn_ui_clkout3_0,
 
       -- Connect the ICAP
-      ICAP_i               => icap_i,  -- This is the input data to the ICAP primitive
-      ICAP_o               => icap_o,
-      ICAP_csib            => icap_csib,
-      ICAP_rdwrb           => icap_rdwrb,
+      ICAP_0_i               => icap_0_i,  -- This is the input data to the ICAP primitive
+      ICAP_0_o               => icap_0_o,
+      ICAP_0_csib            => icap_0_csib,
+      ICAP_0_rdwrb           => icap_0_rdwrb,
+      
+      ICAP_0_avail => ICAP_0_avail,
       
       -- Connect to memory
-      ddr3_sdram_addr      => ddr3_sdram_addr,
-      ddr3_sdram_ba        => ddr3_sdram_ba,
-      ddr3_sdram_cas_n     => ddr3_sdram_cas_n,
-      ddr3_sdram_ck_n      => ddr3_sdram_ck_n,
-      ddr3_sdram_ck_p      => ddr3_sdram_ck_p,
-      ddr3_sdram_cke       => ddr3_sdram_cke,
-      ddr3_sdram_cs_n      => ddr3_sdram_cs_n,
-      ddr3_sdram_dm        => ddr3_sdram_dm,
-      ddr3_sdram_dq        => ddr3_sdram_dq,
-      ddr3_sdram_dqs_n     => ddr3_sdram_dqs_n,
-      ddr3_sdram_dqs_p     => ddr3_sdram_dqs_p,
-      ddr3_sdram_odt       => ddr3_sdram_odt,
-      ddr3_sdram_ras_n     => ddr3_sdram_ras_n,
-      ddr3_sdram_reset_n   => ddr3_sdram_reset_n,
-      ddr3_sdram_we_n      => ddr3_sdram_we_n,
+      -- ddr3_sdram_addr      => ddr3_sdram_addr,
+      -- ddr3_sdram_ba        => ddr3_sdram_ba,
+      -- ddr3_sdram_cas_n     => ddr3_sdram_cas_n,
+      -- ddr3_sdram_ck_n      => ddr3_sdram_ck_n,
+      -- ddr3_sdram_ck_p      => ddr3_sdram_ck_p,
+      -- ddr3_sdram_cke       => ddr3_sdram_cke,
+      -- ddr3_sdram_cs_n      => ddr3_sdram_cs_n,
+      -- ddr3_sdram_dm        => ddr3_sdram_dm,
+      -- ddr3_sdram_dq        => ddr3_sdram_dq,
+      -- ddr3_sdram_dqs_n     => ddr3_sdram_dqs_n,
+      -- ddr3_sdram_dqs_p     => ddr3_sdram_dqs_p,
+      -- ddr3_sdram_odt       => ddr3_sdram_odt,
+      -- ddr3_sdram_ras_n     => ddr3_sdram_ras_n,
+      -- ddr3_sdram_reset_n   => ddr3_sdram_reset_n,
+      -- ddr3_sdram_we_n      => ddr3_sdram_we_n,
+      ddr4_sdram_act_n => ddr4_sdram_act_n,
+      ddr4_sdram_adr => ddr4_sdram_adr,
+      ddr4_sdram_ba => ddr4_sdram_ba,
+      ddr4_sdram_bg => ddr4_sdram_bg,
+      ddr4_sdram_ck_c => ddr4_sdram_ck_c,
+      ddr4_sdram_ck_t => ddr4_sdram_ck_t,
+      ddr4_sdram_cke => ddr4_sdram_cke,
+      ddr4_sdram_cs_n => ddr4_sdram_cs_n, 
+      ddr4_sdram_dm_n => ddr4_sdram_dm_n,
+      ddr4_sdram_dq => ddr4_sdram_dq, 
+      ddr4_sdram_dqs_c => ddr4_sdram_dqs_c, 
+      ddr4_sdram_dqs_t => ddr4_sdram_dqs_t, 
+      ddr4_sdram_odt => ddr4_sdram_odt,
+      ddr4_sdram_reset_n => ddr4_sdram_reset_n, 
 
 
       -- Connect to Ethernet
       mdio_mdc_mdc         => mdio_mdc_mdc,
       mdio_mdc_mdio_io     => mdio_mdc_mdio_io,
-      mii_col              => mii_col,
-      mii_crs              => mii_crs,
-      mii_rst_n            => mii_rst_n,
-      mii_rx_clk           => mii_rx_clk,
-      mii_rx_dv            => mii_rx_dv,
-      mii_rx_er            => mii_rx_er,
-      mii_rxd              => mii_rxd,
-      mii_tx_clk           => mii_tx_clk,
-      mii_tx_en            => mii_tx_en,
-      mii_txd              => mii_txd,
+      
+      -- mii_col              => mii_col,
+      -- mii_crs              => mii_crs,
+      -- mii_rst_n            => mii_rst_n,
+      -- mii_rx_clk           => mii_rx_clk,
+      -- mii_rx_dv            => mii_rx_dv,
+      -- mii_rx_er            => mii_rx_er,
+      -- mii_rxd              => mii_rxd,
+      -- mii_tx_clk           => mii_tx_clk,
+      -- mii_tx_en            => mii_tx_en,
+      -- mii_txd              => mii_txd,
+      sgmii_lvds_rxn => sgmii_lvds_rxn,
+      sgmii_lvds_rxp => sgmii_lvds_rxp,
+      sgmii_lvds_txn => sgmii_lvds_txn,
+      sgmii_lvds_txp => sgmii_lvds_txp,
+      sgmii_phyclk_clk_n => sgmii_phyclk_clk_n,
+      sgmii_phyclk_clk_p => sgmii_phyclk_clk_p,
 
-      rs232_uart_rxd       => rs232_uart_rxd,
-      rs232_uart_txd       => rs232_uart_txd
+      dummy_port_in => dummy_port_in,
+      
+      -- rs232_uart_rxd       => rs232_uart_rxd,
+      -- rs232_uart_txd       => rs232_uart_txd
+      rs232_uart_0_rxd => rs232_uart_0_rxd,
+      rs232_uart_0_txd => rs232_uart_0_txd
       );
   
 
@@ -213,7 +310,7 @@ begin
   inst_shift : shift
     port map (
       en       => '0',
-      clk      => clk_100,
+      clk      => addn_ui_clkout3_0,
       addr     => count_value(34 downto 23),
       data_out => shift_out
       );
@@ -222,24 +319,72 @@ begin
   inst_count : count
     port map (
       rst       => '0',
-      clk       => clk_100,
+      clk       => addn_ui_clkout3_0,
       count_out => count_out
       );
 
-  -- Instantiate ICAP primitive
-  --
-  ICAPE2_inst : ICAPE2
-    generic map (
-      DEVICE_ID  => X"3651093",         -- Device ID code for Kintex-7 XC7K325T-2FFG900C
-      ICAP_WIDTH => "X32"               -- Specifies the input and output data width to be used with the ICAPE2.
-      )
-    port map (
-      O          => icap_o,             -- 32-bit output: Configuration data output bus
-      CLK        => clk_100,            -- 1-bit input: Clock Input
-      CSIB       => icap_csib,          -- 1-bit input: Active-Low ICAP Enable
-      I          => icap_i,             -- 32-bit input: Configuration data input bus
-      RDWRB      => icap_rdwrb          -- 1-bit input: Read/Write Select input
-      );
+  -- -- Instantiate ICAP primitive
+  -- --
+  -- ICAPE2_inst : ICAPE2
+  --   generic map (
+  --     DEVICE_ID  => X"3651093",         -- Device ID code for Kintex-7 XC7K325T-2FFG900C
+  --     ICAP_WIDTH => "X32"               -- Specifies the input and output data width to be used with the ICAPE2.
+  --     )
+  --   port map (
+  --     O          => icap_o,             -- 32-bit output: Configuration data output bus
+  --     CLK        => addn_ui_clkout3_0,            -- 1-bit input: Clock Input
+  --     CSIB       => icap_csib,          -- 1-bit input: Active-Low ICAP Enable
+  --     I          => icap_i,             -- 32-bit input: Configuration data input bus
+  --     RDWRB      => icap_rdwrb          -- 1-bit input: Read/Write Select input
+  --     );
+
+
+--   ICAPE3    : In order to incorporate this function into the design,
+--    VHDL     : the following instance declaration needs to be placed
+--  instance   : in the body of the design code.  The instance name
+-- declaration : (ICAPE3_inst) and/or the port declarations after the
+--    code     : "=>" declaration maybe changed to properly reference and
+--             : connect this function to the design.  All inputs and outputs
+--             : must be connected.
+
+--   Library   : In addition to adding the instance declaration, a use
+-- declaration : statement for the UNISIM.vcomponents library needs to be
+--     for     : added before the entity declaration.  This library
+--   Xilinx    : contains the component declarations for all Xilinx
+-- primitives  : primitives and points to the models that will be used
+--             : for simulation.
+
+--  Copy the following two statements and paste them before the
+--  Entity declaration, unless they already exist.
+
+-- <-----Cut code below this line and paste into the architecture body---->
+
+   -- ICAPE3: Internal Configuration Access Port
+   --         Virtex UltraScale+
+   -- Xilinx HDL Language Template, version 2019.1
+
+   ICAPE3_inst : ICAPE3
+   generic map (
+      DEVICE_ID => X"03628093",      -- Specifies the pre-programmed Device ID value to be used for simulation
+                                     -- purposes.
+      ICAP_AUTO_SWITCH => "DISABLE", -- Enable switch ICAP using sync word
+      SIM_CFG_FILE_NAME => "NONE"    -- Specifies the Raw Bitstream (RBT) file to be parsed by the simulation
+                                     -- model
+   )
+   port map (
+      AVAIL => ICAP_0_avail,     -- 1-bit output: Availability status of ICAP
+      O => icap_0_o,             -- 32-bit output: Configuration data output bus
+      -- PRDONE => PRDONE,   -- 1-bit output: Indicates completion of Partial Reconfiguration
+      -- PRERROR => PRERROR, -- 1-bit output: Indicates Error during Partial Reconfiguration
+      CLK => addn_ui_clkout3_0,         -- 1-bit input: Clock input
+      CSIB => icap_0_csib,       -- 1-bit input: Active-Low ICAP enable
+      I => icap_0_i,             -- 32-bit input: Configuration data input bus
+      RDWRB => icap_0_rdwrb      -- 1-bit input: Read/Write Select input
+   );
+
+   -- End of ICAPE3_inst instantiation
+				
+
 
 
   b_ila_icap            : block
@@ -247,16 +392,17 @@ begin
     signal icap_rdwrb_v : std_logic_vector(0 downto 0);
     signal icap_status  : std_logic_vector(3 downto 0);
   begin
-    icap_csib_v(0)  <= icap_csib;
-    icap_rdwrb_v(0) <= icap_rdwrb;
-    icap_status     <= icap_o(7 downto 4);
+    icap_csib_v(0)  <= icap_0_csib;
+    icap_rdwrb_v(0) <= icap_0_rdwrb;
+    icap_status     <= icap_0_o(7 downto 4);
 
     i_ila_icap : ila_icap
       port map (
-        clk          => clk_100,
+        clk          => addn_ui_clkout3_0,
         trig_out     => open,
         trig_out_ack => '1',
-        probe0       => icap_i,
+
+        probe0       => icap_0_i,
         probe1       => icap_status,
         probe2       => icap_csib_v,
         probe3       => icap_rdwrb_v
@@ -267,9 +413,9 @@ begin
   -- Misc
   -- -------------------------------------------------------------------------
   -- This counter provides an address for the shift Virtual Socket where it is used to address a BRAM
-  p_count : process (clk_100)
+  p_count : process (addn_ui_clkout3_0)
   begin
-    if rising_edge(clk_100) then
+    if rising_edge(addn_ui_clkout3_0) then
       if reset = '1' then
         count_value <= (others => '0');
       else

--- a/xapp1292-loading-partial-bitstreams-using-tftp/example_3/create_ipi_design_0.tcl
+++ b/xapp1292-loading-partial-bitstreams-using-tftp/example_3/create_ipi_design_0.tcl
@@ -1,0 +1,660 @@
+close_project -quiet
+source ../common/set_part.tcl -notrace
+create_project project ./project -part $part  -force
+set_property board_part $board [current_project]
+set_property target_language VHDL [current_project]
+create_bd_design "static_bd"
+
+
+# # =======================================================================
+# # Create the MIG
+# # =======================================================================
+# create_bd_cell -type ip -vlnv xilinx.com:ip:mig_7series mig
+# apply_bd_automation -rule xilinx.com:bd_rule:mig_7series -config {Board_Interface "ddr3_sdram" }  [get_bd_cells mig]
+# apply_bd_automation -rule xilinx.com:bd_rule:board -config {Board_Interface "reset ( FPGA Reset ) " }  [get_bd_pins mig/sys_rst]
+
+# # =======================================================================
+# # Create the Microblaze
+# # =======================================================================
+# create_bd_cell -type ip -vlnv xilinx.com:ip:microblaze cpu
+# apply_bd_automation -rule xilinx.com:bd_rule:microblaze -config {local_mem "128KB" ecc "None" cache "None" debug_module "Debug Only" axi_periph "Enabled" axi_intc "1" clk "/mig/ui_clk (100 MHz)" }  [get_bd_cells cpu]
+# set_property -dict [list CONFIG.C_NUMBER_OF_PC_BRK {8} CONFIG.C_NUMBER_OF_RD_ADDR_BRK {4} CONFIG.C_NUMBER_OF_WR_ADDR_BRK {4}] [get_bd_cells cpu]
+# apply_bd_automation -rule xilinx.com:bd_rule:axi4 -config {Master "/cpu (Periph)" Clk "Auto" }  [get_bd_intf_pins mig/S_AXI]
+
+# set_property range 1M [get_bd_addr_segs {cpu/Data/SEG_dlmb_bram_if_cntlr_Mem}]
+# set_property range 1M [get_bd_addr_segs {cpu/Instruction/SEG_ilmb_bram_if_cntlr_Mem}]
+
+# set_property -dict [list CONFIG.NUM_PORTS {4}] [get_bd_cells cpu_xlconcat]
+
+
+# # =======================================================================
+# # Create the Ethernet
+# # =======================================================================
+
+# create_bd_cell -type ip -vlnv xilinx.com:ip:axi_ethernetlite:3.0 ethernet
+# set_property -dict [list CONFIG.MII_BOARD_INTERFACE {mii} CONFIG.MDIO_BOARD_INTERFACE {mdio_mdc}] [get_bd_cells ethernet]
+# apply_bd_automation -rule xilinx.com:bd_rule:axi4 -config {Master "/cpu (Periph)" Clk "Auto" }  [get_bd_intf_pins ethernet/S_AXI]
+# apply_bd_automation -rule xilinx.com:bd_rule:board -config {Board_Interface "mii ( Onboard PHY ) " }  [get_bd_intf_pins ethernet/MII]
+# apply_bd_automation -rule xilinx.com:bd_rule:board -config {Board_Interface "mdio_mdc ( Onboard PHY ) " }  [get_bd_intf_pins ethernet/MDIO]
+# connect_bd_net [get_bd_pins ethernet/ip2intc_irpt] [get_bd_pins cpu_xlconcat/In2]
+
+
+
+# # =======================================================================
+# # Create the UART
+# # =======================================================================
+# create_bd_cell -type ip -vlnv xilinx.com:ip:axi_uartlite:2.0 uart
+# apply_bd_automation -rule xilinx.com:bd_rule:axi4 -config {Master "/cpu (Periph)" Clk "Auto" }  [get_bd_intf_pins uart/S_AXI]
+# apply_bd_automation -rule xilinx.com:bd_rule:board -config {Board_Interface "rs232_uart" }  [get_bd_intf_pins uart/UART]
+# connect_bd_net [get_bd_pins uart/interrupt] [get_bd_pins cpu_xlconcat/In0]
+
+
+# # =======================================================================
+# # Create the timer
+# # =======================================================================
+# create_bd_cell -type ip -vlnv xilinx.com:ip:axi_timer:2.0 timer
+# apply_bd_automation -rule xilinx.com:bd_rule:axi4 -config {Master "/cpu (Periph)" Clk "Auto" }  [get_bd_intf_pins timer/S_AXI]
+# connect_bd_net [get_bd_pins timer/interrupt] [get_bd_pins cpu_xlconcat/In1]
+
+
+# # =======================================================================
+# # |                        Generate AXI HWICAP                          | 
+# # =======================================================================
+
+# create_bd_cell -type ip -vlnv xilinx.com:ip:axi_hwicap:3.0 axi_hwicap_0
+# set_property -dict [list CONFIG.C_ICAP_EXTERNAL {1}] [get_bd_cells axi_hwicap_0]
+# set_property -dict [list CONFIG.C_WRITE_FIFO_DEPTH {1024} CONFIG.C_OPERATION {0}] [get_bd_cells axi_hwicap_0]
+# set_property -dict [list CONFIG.C_INCLUDE_STARTUP {1}] [get_bd_cells axi_hwicap_0]
+# create_bd_intf_port -mode Master -vlnv xilinx.com:interface:icap_rtl:1.0 ICAP
+# connect_bd_intf_net [get_bd_intf_pins axi_hwicap_0/ICAP] [get_bd_intf_ports ICAP]
+# connect_bd_net [get_bd_pins axi_hwicap_0/icap_clk] [get_bd_pins mig/ui_clk]
+# connect_bd_net [get_bd_pins axi_hwicap_0/s_axi_aclk] [get_bd_pins mig/ui_clk]
+# connect_bd_net [get_bd_pins axi_hwicap_0/s_axi_aresetn] [get_bd_pins rst_mig_100M/peripheral_aresetn]
+# connect_bd_net [get_bd_pins axi_hwicap_0/ip2intc_irpt] [get_bd_pins cpu_xlconcat/In3]
+# apply_bd_automation -rule xilinx.com:bd_rule:axi4 -config {Master "/cpu (Periph)" Clk "Auto" }  [get_bd_intf_pins axi_hwicap_0/S_AXI_LITE]
+
+# create_bd_cell -type ip -vlnv xilinx.com:ip:xlconstant:1.1 constant_0
+# set_property -dict [list CONFIG.CONST_VAL {0}] [get_bd_cells constant_0]
+
+# create_bd_cell -type ip -vlnv xilinx.com:ip:xlconstant:1.1 constant_1
+# set_property -dict [list CONFIG.CONST_VAL {1}] [get_bd_cells constant_1]
+
+# connect_bd_net [get_bd_pins constant_1/dout] [get_bd_pins axi_hwicap_0/cap_gnt]
+# connect_bd_net [get_bd_pins constant_0/dout] [get_bd_pins axi_hwicap_0/cap_rel]
+
+
+
+# create_bd_port -dir O -type clk clk_100
+# connect_bd_net [get_bd_pins /mig/ui_clk] [get_bd_ports clk_100]
+##################################################################
+# CHECK IPs
+##################################################################
+set bCheckIPs 1
+if { $bCheckIPs == 1 } {
+   set list_check_ips "\ 
+xilinx.com:ip:axi_bram_ctrl:4.1\
+xilinx.com:ip:blk_mem_gen:8.4\
+xilinx.com:ip:axi_ethernet:7.1\
+xilinx.com:ip:axi_dma:7.1\
+xilinx.com:ip:axi_hwicap:3.0\
+xilinx.com:ip:axi_quad_spi:3.2\
+xilinx.com:ip:axi_timer:2.0\
+xilinx.com:ip:axi_uart16550:2.0\
+xilinx.com:ip:ddr4:2.2\
+xilinx.com:ip:ila:6.2\
+xilinx.com:ip:jtag_axi:1.2\
+xilinx.com:ip:mdm:3.2\
+xilinx.com:ip:microblaze:11.0\
+xilinx.com:ip:axi_intc:4.1\
+xilinx.com:ip:xlconcat:2.1\
+xilinx.com:ip:proc_sys_reset:5.0\
+xilinx.com:ip:system_ila:1.1\
+xilinx.com:ip:xlconstant:1.1\
+xilinx.com:ip:lmb_bram_if_cntlr:4.0\
+xilinx.com:ip:lmb_v10:3.0\
+"
+
+   set list_ips_missing ""
+   common::send_msg_id "BD_TCL-006" "INFO" "Checking if the following IPs exist in the project's IP catalog: $list_check_ips ."
+
+   foreach ip_vlnv $list_check_ips {
+      set ip_obj [get_ipdefs -all $ip_vlnv]
+      if { $ip_obj eq "" } {
+         lappend list_ips_missing $ip_vlnv
+      }
+   }
+
+
+
+}
+
+
+
+##################################################################
+# DESIGN PROCs
+##################################################################
+
+
+# Hierarchical cell: microblaze_0_local_memory
+proc create_hier_cell_microblaze_0_local_memory { parentCell nameHier } {
+
+  variable script_folder
+
+  if { $parentCell eq "" || $nameHier eq "" } {
+     catch {common::send_msg_id "BD_TCL-102" "ERROR" "create_hier_cell_microblaze_0_local_memory() - Empty argument(s)!"}
+     return
+  }
+
+  # Get object for parentCell
+  set parentObj [get_bd_cells $parentCell]
+  if { $parentObj == "" } {
+     catch {common::send_msg_id "BD_TCL-100" "ERROR" "Unable to find parent cell <$parentCell>!"}
+     return
+  }
+
+  # Make sure parentObj is hier blk
+  set parentType [get_property TYPE $parentObj]
+  if { $parentType ne "hier" } {
+     catch {common::send_msg_id "BD_TCL-101" "ERROR" "Parent <$parentObj> has TYPE = <$parentType>. Expected to be <hier>."}
+     return
+  }
+
+  # Save current instance; Restore later
+  set oldCurInst [current_bd_instance .]
+
+  # Set parent object as current
+  current_bd_instance $parentObj
+
+  # Create cell and set as current instance
+  set hier_obj [create_bd_cell -type hier $nameHier]
+  current_bd_instance $hier_obj
+
+  # Create interface pins
+  create_bd_intf_pin -mode MirroredMaster -vlnv xilinx.com:interface:lmb_rtl:1.0 DLMB
+
+  create_bd_intf_pin -mode MirroredMaster -vlnv xilinx.com:interface:lmb_rtl:1.0 ILMB
+
+
+  # Create pins
+  create_bd_pin -dir I -type clk LMB_Clk
+  create_bd_pin -dir I -from 0 -to 0 -type rst SYS_Rst
+
+  # Create instance: dlmb_bram_if_cntlr, and set properties
+  set dlmb_bram_if_cntlr [ create_bd_cell -type ip -vlnv xilinx.com:ip:lmb_bram_if_cntlr:4.0 dlmb_bram_if_cntlr ]
+  set_property -dict [ list \
+   CONFIG.C_ECC {0} \
+ ] $dlmb_bram_if_cntlr
+
+  # Create instance: dlmb_v10, and set properties
+  set dlmb_v10 [ create_bd_cell -type ip -vlnv xilinx.com:ip:lmb_v10:3.0 dlmb_v10 ]
+
+  # Create instance: ilmb_bram_if_cntlr, and set properties
+  set ilmb_bram_if_cntlr [ create_bd_cell -type ip -vlnv xilinx.com:ip:lmb_bram_if_cntlr:4.0 ilmb_bram_if_cntlr ]
+  set_property -dict [ list \
+   CONFIG.C_ECC {0} \
+ ] $ilmb_bram_if_cntlr
+
+  # Create instance: ilmb_v10, and set properties
+  set ilmb_v10 [ create_bd_cell -type ip -vlnv xilinx.com:ip:lmb_v10:3.0 ilmb_v10 ]
+
+  # Create instance: lmb_bram, and set properties
+  set lmb_bram [ create_bd_cell -type ip -vlnv xilinx.com:ip:blk_mem_gen:8.4 lmb_bram ]
+  set_property -dict [ list \
+   CONFIG.Memory_Type {True_Dual_Port_RAM} \
+   CONFIG.use_bram_block {BRAM_Controller} \
+ ] $lmb_bram
+
+  # Create interface connections
+  connect_bd_intf_net -intf_net microblaze_0_dlmb [get_bd_intf_pins DLMB] [get_bd_intf_pins dlmb_v10/LMB_M]
+  connect_bd_intf_net -intf_net microblaze_0_dlmb_bus [get_bd_intf_pins dlmb_bram_if_cntlr/SLMB] [get_bd_intf_pins dlmb_v10/LMB_Sl_0]
+  connect_bd_intf_net -intf_net microblaze_0_dlmb_cntlr [get_bd_intf_pins dlmb_bram_if_cntlr/BRAM_PORT] [get_bd_intf_pins lmb_bram/BRAM_PORTA]
+  connect_bd_intf_net -intf_net microblaze_0_ilmb [get_bd_intf_pins ILMB] [get_bd_intf_pins ilmb_v10/LMB_M]
+  connect_bd_intf_net -intf_net microblaze_0_ilmb_bus [get_bd_intf_pins ilmb_bram_if_cntlr/SLMB] [get_bd_intf_pins ilmb_v10/LMB_Sl_0]
+  connect_bd_intf_net -intf_net microblaze_0_ilmb_cntlr [get_bd_intf_pins ilmb_bram_if_cntlr/BRAM_PORT] [get_bd_intf_pins lmb_bram/BRAM_PORTB]
+
+  # Create port connections
+  connect_bd_net -net SYS_Rst_1 [get_bd_pins SYS_Rst] [get_bd_pins dlmb_bram_if_cntlr/LMB_Rst] [get_bd_pins dlmb_v10/SYS_Rst] [get_bd_pins ilmb_bram_if_cntlr/LMB_Rst] [get_bd_pins ilmb_v10/SYS_Rst]
+  connect_bd_net -net microblaze_0_Clk [get_bd_pins LMB_Clk] [get_bd_pins dlmb_bram_if_cntlr/LMB_Clk] [get_bd_pins dlmb_v10/LMB_Clk] [get_bd_pins ilmb_bram_if_cntlr/LMB_Clk] [get_bd_pins ilmb_v10/LMB_Clk]
+
+  # Restore current instance
+  current_bd_instance $oldCurInst
+}
+
+
+# Procedure to create entire design; Provide argument to make
+# procedure reusable. If parentCell is "", will use root.
+proc create_root_design { parentCell } {
+
+  variable script_folder
+  variable design_name
+
+  if { $parentCell eq "" } {
+     set parentCell [get_bd_cells /]
+  }
+
+  # Get object for parentCell
+  set parentObj [get_bd_cells $parentCell]
+  if { $parentObj == "" } {
+     catch {common::send_msg_id "BD_TCL-100" "ERROR" "Unable to find parent cell <$parentCell>!"}
+     return
+  }
+
+  # Make sure parentObj is hier blk
+  set parentType [get_property TYPE $parentObj]
+  if { $parentType ne "hier" } {
+     catch {common::send_msg_id "BD_TCL-101" "ERROR" "Parent <$parentObj> has TYPE = <$parentType>. Expected to be <hier>."}
+     return
+  }
+
+  # Save current instance; Restore later
+  set oldCurInst [current_bd_instance .]
+
+  # Set parent object as current
+  current_bd_instance $parentObj
+
+
+  # Create interface ports
+  set ICAP_0 [ create_bd_intf_port -mode Master -vlnv xilinx.com:interface:icap_rtl:1.0 ICAP_0 ]
+
+  set ddr4_sdram [ create_bd_intf_port -mode Master -vlnv xilinx.com:interface:ddr4_rtl:1.0 ddr4_sdram ]
+
+  set default_100mhz_clk [ create_bd_intf_port -mode Slave -vlnv xilinx.com:interface:diff_clock_rtl:1.0 default_100mhz_clk ]
+  set_property -dict [ list \
+   CONFIG.FREQ_HZ {100000000} \
+   ] $default_100mhz_clk
+
+  set mdio_mdc [ create_bd_intf_port -mode Master -vlnv xilinx.com:interface:mdio_rtl:1.0 mdio_mdc ]
+
+  set rs232_uart_0 [ create_bd_intf_port -mode Master -vlnv xilinx.com:interface:uart_rtl:1.0 rs232_uart_0 ]
+
+  set sgmii_lvds [ create_bd_intf_port -mode Master -vlnv xilinx.com:interface:sgmii_rtl:1.0 sgmii_lvds ]
+
+  set sgmii_phyclk [ create_bd_intf_port -mode Slave -vlnv xilinx.com:interface:diff_clock_rtl:1.0 sgmii_phyclk ]
+  set_property -dict [ list \
+   CONFIG.FREQ_HZ {625000000} \
+   ] $sgmii_phyclk
+
+
+  # Create ports
+  set addn_ui_clkout3_0 [ create_bd_port -dir O -type clk addn_ui_clkout3_0 ]
+  set_property -dict [ list \
+   CONFIG.FREQ_HZ {10000000} \
+ ] $addn_ui_clkout3_0
+  set dummy_port_in [ create_bd_port -dir I -type rst dummy_port_in ]
+  set_property -dict [ list \
+   CONFIG.POLARITY {ACTIVE_HIGH} \
+ ] $dummy_port_in
+  set reset [ create_bd_port -dir I -type rst reset ]
+  set_property -dict [ list \
+   CONFIG.POLARITY {ACTIVE_HIGH} \
+ ] $reset
+
+  # Create instance: axi_bram_ctrl_0, and set properties
+  set axi_bram_ctrl_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:axi_bram_ctrl:4.1 axi_bram_ctrl_0 ]
+
+  # Create instance: axi_bram_ctrl_0_bram, and set properties
+  set axi_bram_ctrl_0_bram [ create_bd_cell -type ip -vlnv xilinx.com:ip:blk_mem_gen:8.4 axi_bram_ctrl_0_bram ]
+  set_property -dict [ list \
+   CONFIG.Memory_Type {True_Dual_Port_RAM} \
+ ] $axi_bram_ctrl_0_bram
+
+  # Create instance: axi_ethernet_0, and set properties
+  set axi_ethernet_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:axi_ethernet:7.1 axi_ethernet_0 ]
+  set_property -dict [ list \
+   CONFIG.DIFFCLK_BOARD_INTERFACE {sgmii_phyclk} \
+   CONFIG.ENABLE_LVDS {true} \
+   CONFIG.ETHERNET_BOARD_INTERFACE {sgmii_lvds} \
+   CONFIG.InstantiateBitslice0 {true} \
+   CONFIG.MDIO_BOARD_INTERFACE {mdio_mdc} \
+   CONFIG.PHYRST_BOARD_INTERFACE {Custom} \
+   CONFIG.PHYRST_BOARD_INTERFACE_DUMMY_PORT {dummy_port_in} \
+   CONFIG.PHY_TYPE {SGMII} \
+   CONFIG.lvdsclkrate {625} \
+   CONFIG.rxlane0_placement {DIFF_PAIR_2} \
+   CONFIG.rxnibblebitslice0used {false} \
+   CONFIG.txlane0_placement {DIFF_PAIR_1} \
+ ] $axi_ethernet_0
+
+  set_property -dict [ list \
+   CONFIG.POLARITY {ACTIVE_LOW} \
+ ] [get_bd_pins /axi_ethernet_0/axi_rxd_arstn]
+
+  set_property -dict [ list \
+   CONFIG.POLARITY {ACTIVE_LOW} \
+ ] [get_bd_pins /axi_ethernet_0/axi_rxs_arstn]
+
+  set_property -dict [ list \
+   CONFIG.POLARITY {ACTIVE_LOW} \
+ ] [get_bd_pins /axi_ethernet_0/axi_txc_arstn]
+
+  set_property -dict [ list \
+   CONFIG.POLARITY {ACTIVE_LOW} \
+ ] [get_bd_pins /axi_ethernet_0/axi_txd_arstn]
+
+  set_property -dict [ list \
+   CONFIG.ASSOCIATED_BUSIF {m_axis_rxd:m_axis_rxs:s_axis_txc:s_axis_txd} \
+   CONFIG.ASSOCIATED_RESET {axi_rxd_arstn:axi_rxs_arstn:axi_txc_arstn:axi_txd_arstn} \
+ ] [get_bd_pins /axi_ethernet_0/axis_clk]
+
+  set_property -dict [ list \
+   CONFIG.ASSOCIATED_RESET {rst_125_out} \
+ ] [get_bd_pins /axi_ethernet_0/clk125_out]
+
+  set_property -dict [ list \
+   CONFIG.POLARITY {ACTIVE_HIGH} \
+ ] [get_bd_pins /axi_ethernet_0/dummy_port_in]
+
+  set_property -dict [ list \
+   CONFIG.SENSITIVITY {LEVEL_HIGH} \
+ ] [get_bd_pins /axi_ethernet_0/interrupt]
+
+  set_property -dict [ list \
+   CONFIG.SENSITIVITY {EDGE_RISING} \
+ ] [get_bd_pins /axi_ethernet_0/mac_irq]
+
+  set_property -dict [ list \
+   CONFIG.POLARITY {ACTIVE_LOW} \
+ ] [get_bd_pins /axi_ethernet_0/phy_rst_n]
+
+  set_property -dict [ list \
+   CONFIG.POLARITY {ACTIVE_HIGH} \
+ ] [get_bd_pins /axi_ethernet_0/rst_125_out]
+
+  set_property -dict [ list \
+   CONFIG.ASSOCIATED_BUSIF {s_axi} \
+   CONFIG.ASSOCIATED_RESET {s_axi_lite_resetn} \
+ ] [get_bd_pins /axi_ethernet_0/s_axi_lite_clk]
+
+  set_property -dict [ list \
+   CONFIG.POLARITY {ACTIVE_LOW} \
+ ] [get_bd_pins /axi_ethernet_0/s_axi_lite_resetn]
+
+  # Create instance: axi_ethernet_0_dma, and set properties
+  set axi_ethernet_0_dma [ create_bd_cell -type ip -vlnv xilinx.com:ip:axi_dma:7.1 axi_ethernet_0_dma ]
+  set_property -dict [ list \
+   CONFIG.c_include_mm2s_dre {1} \
+   CONFIG.c_include_s2mm_dre {1} \
+   CONFIG.c_sg_length_width {16} \
+   CONFIG.c_sg_use_stsapp_length {1} \
+ ] $axi_ethernet_0_dma
+
+  # Create instance: axi_hwicap_0, and set properties
+  set axi_hwicap_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:axi_hwicap:3.0 axi_hwicap_0 ]
+  set_property -dict [ list \
+   CONFIG.C_ICAP_EXTERNAL {1} \
+   CONFIG.C_WRITE_FIFO_DEPTH {1024} \
+ ] $axi_hwicap_0
+
+  # Create instance: axi_mem_intercon, and set properties
+  set axi_mem_intercon [ create_bd_cell -type ip -vlnv xilinx.com:ip:axi_interconnect:2.1 axi_mem_intercon ]
+  set_property -dict [ list \
+   CONFIG.NUM_MI {2} \
+   CONFIG.NUM_SI {5} \
+ ] $axi_mem_intercon
+
+  # Create instance: axi_quad_spi_0, and set properties
+  set axi_quad_spi_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:axi_quad_spi:3.2 axi_quad_spi_0 ]
+  set_property -dict [ list \
+   CONFIG.C_FIFO_DEPTH {256} \
+   CONFIG.C_SPI_MEMORY {2} \
+   CONFIG.C_SPI_MEM_ADDR_BITS {24} \
+   CONFIG.C_SPI_MODE {2} \
+   CONFIG.C_TYPE_OF_AXI4_INTERFACE {0} \
+   CONFIG.C_USE_STARTUP {1} \
+   CONFIG.C_USE_STARTUP_INT {1} \
+   CONFIG.C_XIP_MODE {0} \
+ ] $axi_quad_spi_0
+
+  # Create instance: axi_timer_0, and set properties
+  set axi_timer_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:axi_timer:2.0 axi_timer_0 ]
+
+  # Create instance: axi_uart16550_0, and set properties
+  set axi_uart16550_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:axi_uart16550:2.0 axi_uart16550_0 ]
+  set_property -dict [ list \
+   CONFIG.UART_BOARD_INTERFACE {rs232_uart_0} \
+   CONFIG.USE_BOARD_FLOW {true} \
+ ] $axi_uart16550_0
+
+  # Create instance: ddr4_0, and set properties
+  set ddr4_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:ddr4:2.2 ddr4_0 ]
+  set_property -dict [ list \
+   CONFIG.ADDN_UI_CLKOUT1_FREQ_HZ {100} \
+   CONFIG.ADDN_UI_CLKOUT2_FREQ_HZ {40} \
+   CONFIG.ADDN_UI_CLKOUT3_FREQ_HZ {10} \
+   CONFIG.C0.DDR4_AxiAddressWidth {32} \
+   CONFIG.C0.DDR4_AxiDataWidth {512} \
+   CONFIG.C0.DDR4_DataWidth {72} \
+   CONFIG.C0.DDR4_InputClockPeriod {10000} \
+   CONFIG.C0.DDR4_MemoryPart {MT40A512M16HA-075E} \
+   CONFIG.C0_CLOCK_BOARD_INTERFACE {default_100mhz_clk} \
+   CONFIG.C0_DDR4_BOARD_INTERFACE {ddr4_sdram} \
+   CONFIG.RESET_BOARD_INTERFACE {reset} \
+ ] $ddr4_0
+
+  # Create instance: ila_3, and set properties
+  set ila_3 [ create_bd_cell -type ip -vlnv xilinx.com:ip:ila:6.2 ila_3 ]
+  set_property -dict [ list \
+   CONFIG.ALL_PROBE_SAME_MU_CNT {2} \
+   CONFIG.C_ADV_TRIGGER {true} \
+   CONFIG.C_DATA_DEPTH {4096} \
+   CONFIG.C_ENABLE_ILA_AXI_MON {false} \
+   CONFIG.C_EN_STRG_QUAL {1} \
+   CONFIG.C_INPUT_PIPE_STAGES {3} \
+   CONFIG.C_MONITOR_TYPE {Native} \
+   CONFIG.C_NUM_OF_PROBES {1} \
+   CONFIG.C_PROBE0_MU_CNT {2} \
+ ] $ila_3
+
+  # Create instance: jtag_axi_0, and set properties
+  set jtag_axi_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:jtag_axi:1.2 jtag_axi_0 ]
+
+  # Create instance: mdm_1, and set properties
+  set mdm_1 [ create_bd_cell -type ip -vlnv xilinx.com:ip:mdm:3.2 mdm_1 ]
+
+  # Create instance: microblaze_0, and set properties
+  set microblaze_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:microblaze:11.0 microblaze_0 ]
+  set_property -dict [ list \
+   CONFIG.C_CACHE_BYTE_SIZE {65536} \
+   CONFIG.C_DCACHE_BYTE_SIZE {65536} \
+   CONFIG.C_DEBUG_ENABLED {1} \
+   CONFIG.C_D_AXI {1} \
+   CONFIG.C_D_LMB {1} \
+   CONFIG.C_I_AXI {1} \
+   CONFIG.C_I_LMB {1} \
+   CONFIG.C_NUMBER_OF_PC_BRK {8} \
+   CONFIG.C_NUMBER_OF_RD_ADDR_BRK {4} \
+   CONFIG.C_NUMBER_OF_WR_ADDR_BRK {4} \
+   CONFIG.C_USE_DCACHE {1} \
+   CONFIG.C_USE_ICACHE {1} \
+ ] $microblaze_0
+
+  # Create instance: microblaze_0_axi_intc, and set properties
+  set microblaze_0_axi_intc [ create_bd_cell -type ip -vlnv xilinx.com:ip:axi_intc:4.1 microblaze_0_axi_intc ]
+  set_property -dict [ list \
+   CONFIG.C_HAS_FAST {1} \
+ ] $microblaze_0_axi_intc
+
+  # Create instance: microblaze_0_axi_periph, and set properties
+  set microblaze_0_axi_periph [ create_bd_cell -type ip -vlnv xilinx.com:ip:axi_interconnect:2.1 microblaze_0_axi_periph ]
+  set_property -dict [ list \
+   CONFIG.NUM_MI {9} \
+   CONFIG.NUM_SI {3} \
+ ] $microblaze_0_axi_periph
+
+  # Create instance: microblaze_0_local_memory
+  create_hier_cell_microblaze_0_local_memory [current_bd_instance .] microblaze_0_local_memory
+
+  # Create instance: microblaze_0_xlconcat, and set properties
+  set microblaze_0_xlconcat [ create_bd_cell -type ip -vlnv xilinx.com:ip:xlconcat:2.1 microblaze_0_xlconcat ]
+  set_property -dict [ list \
+   CONFIG.NUM_PORTS {8} \
+ ] $microblaze_0_xlconcat
+
+  # Create instance: rst_ddr4_0_100M, and set properties
+  set rst_ddr4_0_100M [ create_bd_cell -type ip -vlnv xilinx.com:ip:proc_sys_reset:5.0 rst_ddr4_0_100M ]
+  set_property -dict [ list \
+   CONFIG.RESET_BOARD_INTERFACE {Custom} \
+   CONFIG.USE_BOARD_FLOW {true} \
+ ] $rst_ddr4_0_100M
+
+  # Create instance: rst_ddr4_0_300M, and set properties
+  set rst_ddr4_0_300M [ create_bd_cell -type ip -vlnv xilinx.com:ip:proc_sys_reset:5.0 rst_ddr4_0_300M ]
+
+  # Create instance: system_ila_0, and set properties
+  set system_ila_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:system_ila:1.1 system_ila_0 ]
+  set_property -dict [ list \
+   CONFIG.C_MON_TYPE {INTERFACE} \
+   CONFIG.C_NUM_MONITOR_SLOTS {1} \
+   CONFIG.C_SLOT_0_APC_EN {1} \
+   CONFIG.C_SLOT_0_AXI_AR_SEL_DATA {1} \
+   CONFIG.C_SLOT_0_AXI_AR_SEL_TRIG {1} \
+   CONFIG.C_SLOT_0_AXI_AW_SEL_DATA {1} \
+   CONFIG.C_SLOT_0_AXI_AW_SEL_TRIG {1} \
+   CONFIG.C_SLOT_0_AXI_B_SEL_DATA {1} \
+   CONFIG.C_SLOT_0_AXI_B_SEL_TRIG {1} \
+   CONFIG.C_SLOT_0_AXI_R_SEL_DATA {1} \
+   CONFIG.C_SLOT_0_AXI_R_SEL_TRIG {1} \
+   CONFIG.C_SLOT_0_AXI_W_SEL_DATA {1} \
+   CONFIG.C_SLOT_0_AXI_W_SEL_TRIG {1} \
+   CONFIG.C_SLOT_0_INTF_TYPE {xilinx.com:interface:aximm_rtl:1.0} \
+ ] $system_ila_0
+
+  # Create instance: xlconstant_0, and set properties
+  set xlconstant_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:xlconstant:1.1 xlconstant_0 ]
+  set_property -dict [ list \
+   CONFIG.CONST_VAL {0} \
+ ] $xlconstant_0
+
+  # Create instance: xlconstant_1, and set properties
+  set xlconstant_1 [ create_bd_cell -type ip -vlnv xilinx.com:ip:xlconstant:1.1 xlconstant_1 ]
+
+  # Create interface connections
+  connect_bd_intf_net -intf_net axi_bram_ctrl_0_BRAM_PORTA [get_bd_intf_pins axi_bram_ctrl_0/BRAM_PORTA] [get_bd_intf_pins axi_bram_ctrl_0_bram/BRAM_PORTA]
+  connect_bd_intf_net -intf_net axi_bram_ctrl_0_BRAM_PORTB [get_bd_intf_pins axi_bram_ctrl_0/BRAM_PORTB] [get_bd_intf_pins axi_bram_ctrl_0_bram/BRAM_PORTB]
+  connect_bd_intf_net -intf_net axi_ethernet_0_dma_M_AXIS_CNTRL [get_bd_intf_pins axi_ethernet_0/s_axis_txc] [get_bd_intf_pins axi_ethernet_0_dma/M_AXIS_CNTRL]
+  connect_bd_intf_net -intf_net axi_ethernet_0_dma_M_AXIS_MM2S [get_bd_intf_pins axi_ethernet_0/s_axis_txd] [get_bd_intf_pins axi_ethernet_0_dma/M_AXIS_MM2S]
+  connect_bd_intf_net -intf_net axi_ethernet_0_dma_M_AXI_MM2S [get_bd_intf_pins axi_ethernet_0_dma/M_AXI_MM2S] [get_bd_intf_pins axi_mem_intercon/S03_AXI]
+  connect_bd_intf_net -intf_net axi_ethernet_0_dma_M_AXI_S2MM [get_bd_intf_pins axi_ethernet_0_dma/M_AXI_S2MM] [get_bd_intf_pins axi_mem_intercon/S04_AXI]
+  connect_bd_intf_net -intf_net axi_ethernet_0_dma_M_AXI_SG [get_bd_intf_pins axi_ethernet_0_dma/M_AXI_SG] [get_bd_intf_pins axi_mem_intercon/S02_AXI]
+  connect_bd_intf_net -intf_net axi_ethernet_0_m_axis_rxd [get_bd_intf_pins axi_ethernet_0/m_axis_rxd] [get_bd_intf_pins axi_ethernet_0_dma/S_AXIS_S2MM]
+  connect_bd_intf_net -intf_net axi_ethernet_0_m_axis_rxs [get_bd_intf_pins axi_ethernet_0/m_axis_rxs] [get_bd_intf_pins axi_ethernet_0_dma/S_AXIS_STS]
+  connect_bd_intf_net -intf_net axi_ethernet_0_mdio [get_bd_intf_ports mdio_mdc] [get_bd_intf_pins axi_ethernet_0/mdio]
+  connect_bd_intf_net -intf_net axi_ethernet_0_sgmii [get_bd_intf_ports sgmii_lvds] [get_bd_intf_pins axi_ethernet_0/sgmii]
+  connect_bd_intf_net -intf_net axi_hwicap_0_ICAP [get_bd_intf_ports ICAP_0] [get_bd_intf_pins axi_hwicap_0/ICAP]
+  connect_bd_intf_net -intf_net axi_mem_intercon_M00_AXI [get_bd_intf_pins axi_bram_ctrl_0/S_AXI] [get_bd_intf_pins axi_mem_intercon/M00_AXI]
+  connect_bd_intf_net -intf_net axi_mem_intercon_M01_AXI [get_bd_intf_pins axi_mem_intercon/M01_AXI] [get_bd_intf_pins ddr4_0/C0_DDR4_S_AXI]
+  connect_bd_intf_net -intf_net axi_uart16550_0_UART [get_bd_intf_ports rs232_uart_0] [get_bd_intf_pins axi_uart16550_0/UART]
+  connect_bd_intf_net -intf_net ddr4_0_C0_DDR4 [get_bd_intf_ports ddr4_sdram] [get_bd_intf_pins ddr4_0/C0_DDR4]
+  connect_bd_intf_net -intf_net default_100mhz_clk_1 [get_bd_intf_ports default_100mhz_clk] [get_bd_intf_pins ddr4_0/C0_SYS_CLK]
+  connect_bd_intf_net -intf_net jtag_axi_0_M_AXI [get_bd_intf_pins jtag_axi_0/M_AXI] [get_bd_intf_pins microblaze_0_axi_periph/S02_AXI]
+  connect_bd_intf_net -intf_net microblaze_0_M_AXI_DC [get_bd_intf_pins axi_mem_intercon/S00_AXI] [get_bd_intf_pins microblaze_0/M_AXI_DC]
+  connect_bd_intf_net -intf_net microblaze_0_M_AXI_IC [get_bd_intf_pins axi_mem_intercon/S01_AXI] [get_bd_intf_pins microblaze_0/M_AXI_IC]
+  connect_bd_intf_net -intf_net microblaze_0_M_AXI_IP [get_bd_intf_pins microblaze_0/M_AXI_IP] [get_bd_intf_pins microblaze_0_axi_periph/S01_AXI]
+  connect_bd_intf_net -intf_net microblaze_0_axi_dp [get_bd_intf_pins microblaze_0/M_AXI_DP] [get_bd_intf_pins microblaze_0_axi_periph/S00_AXI]
+  connect_bd_intf_net -intf_net microblaze_0_axi_periph_M01_AXI [get_bd_intf_pins axi_quad_spi_0/AXI_LITE] [get_bd_intf_pins microblaze_0_axi_periph/M01_AXI]
+  connect_bd_intf_net -intf_net microblaze_0_axi_periph_M02_AXI [get_bd_intf_pins axi_uart16550_0/S_AXI] [get_bd_intf_pins microblaze_0_axi_periph/M02_AXI]
+  connect_bd_intf_net -intf_net microblaze_0_axi_periph_M03_AXI [get_bd_intf_pins ddr4_0/C0_DDR4_S_AXI_CTRL] [get_bd_intf_pins microblaze_0_axi_periph/M03_AXI]
+  connect_bd_intf_net -intf_net microblaze_0_axi_periph_M04_AXI [get_bd_intf_pins axi_ethernet_0/s_axi] [get_bd_intf_pins microblaze_0_axi_periph/M04_AXI]
+  connect_bd_intf_net -intf_net microblaze_0_axi_periph_M05_AXI [get_bd_intf_pins axi_ethernet_0_dma/S_AXI_LITE] [get_bd_intf_pins microblaze_0_axi_periph/M05_AXI]
+  connect_bd_intf_net -intf_net microblaze_0_axi_periph_M07_AXI [get_bd_intf_pins axi_timer_0/S_AXI] [get_bd_intf_pins microblaze_0_axi_periph/M07_AXI]
+  connect_bd_intf_net -intf_net microblaze_0_axi_periph_M08_AXI [get_bd_intf_pins axi_hwicap_0/S_AXI_LITE] [get_bd_intf_pins microblaze_0_axi_periph/M08_AXI]
+connect_bd_intf_net -intf_net [get_bd_intf_nets microblaze_0_axi_periph_M08_AXI] [get_bd_intf_pins microblaze_0_axi_periph/M08_AXI] [get_bd_intf_pins system_ila_0/SLOT_0_AXI]
+  set_property HDL_ATTRIBUTE.DEBUG {true} [get_bd_intf_nets microblaze_0_axi_periph_M08_AXI]
+  connect_bd_intf_net -intf_net microblaze_0_debug [get_bd_intf_pins mdm_1/MBDEBUG_0] [get_bd_intf_pins microblaze_0/DEBUG]
+  connect_bd_intf_net -intf_net microblaze_0_dlmb_1 [get_bd_intf_pins microblaze_0/DLMB] [get_bd_intf_pins microblaze_0_local_memory/DLMB]
+  connect_bd_intf_net -intf_net microblaze_0_ilmb_1 [get_bd_intf_pins microblaze_0/ILMB] [get_bd_intf_pins microblaze_0_local_memory/ILMB]
+  connect_bd_intf_net -intf_net microblaze_0_intc_axi [get_bd_intf_pins microblaze_0_axi_intc/s_axi] [get_bd_intf_pins microblaze_0_axi_periph/M00_AXI]
+  connect_bd_intf_net -intf_net microblaze_0_interrupt [get_bd_intf_pins microblaze_0/INTERRUPT] [get_bd_intf_pins microblaze_0_axi_intc/interrupt]
+  connect_bd_intf_net -intf_net sgmii_phyclk_1 [get_bd_intf_ports sgmii_phyclk] [get_bd_intf_pins axi_ethernet_0/lvds_clk]
+
+  # Create port connections
+  connect_bd_net -net M01_ACLK_1 [get_bd_pins axi_ethernet_0/axis_clk] [get_bd_pins axi_ethernet_0_dma/m_axi_mm2s_aclk] [get_bd_pins axi_ethernet_0_dma/m_axi_s2mm_aclk] [get_bd_pins axi_ethernet_0_dma/m_axi_sg_aclk] [get_bd_pins axi_mem_intercon/M01_ACLK] [get_bd_pins axi_mem_intercon/S02_ACLK] [get_bd_pins axi_mem_intercon/S03_ACLK] [get_bd_pins axi_mem_intercon/S04_ACLK] [get_bd_pins ddr4_0/c0_ddr4_ui_clk] [get_bd_pins microblaze_0_axi_periph/M03_ACLK] [get_bd_pins rst_ddr4_0_300M/slowest_sync_clk]
+  connect_bd_net -net axi_ethernet_0_dma_mm2s_cntrl_reset_out_n [get_bd_pins axi_ethernet_0/axi_txc_arstn] [get_bd_pins axi_ethernet_0_dma/mm2s_cntrl_reset_out_n]
+  connect_bd_net -net axi_ethernet_0_dma_mm2s_introut [get_bd_pins axi_ethernet_0_dma/mm2s_introut] [get_bd_pins microblaze_0_xlconcat/In4]
+  connect_bd_net -net axi_ethernet_0_dma_mm2s_prmry_reset_out_n [get_bd_pins axi_ethernet_0/axi_txd_arstn] [get_bd_pins axi_ethernet_0_dma/mm2s_prmry_reset_out_n]
+  connect_bd_net -net axi_ethernet_0_dma_s2mm_introut [get_bd_pins axi_ethernet_0_dma/s2mm_introut] [get_bd_pins microblaze_0_xlconcat/In5]
+  connect_bd_net -net axi_ethernet_0_dma_s2mm_prmry_reset_out_n [get_bd_pins axi_ethernet_0/axi_rxd_arstn] [get_bd_pins axi_ethernet_0_dma/s2mm_prmry_reset_out_n]
+  connect_bd_net -net axi_ethernet_0_dma_s2mm_sts_reset_out_n [get_bd_pins axi_ethernet_0/axi_rxs_arstn] [get_bd_pins axi_ethernet_0_dma/s2mm_sts_reset_out_n]
+  connect_bd_net -net axi_ethernet_0_interrupt [get_bd_pins axi_ethernet_0/interrupt] [get_bd_pins microblaze_0_xlconcat/In2]
+  connect_bd_net -net axi_ethernet_0_mac_irq [get_bd_pins axi_ethernet_0/mac_irq] [get_bd_pins microblaze_0_xlconcat/In3]
+  connect_bd_net -net axi_ethernet_0_phy_rst_n [get_bd_pins axi_ethernet_0/phy_rst_n] [get_bd_pins ila_3/probe0]
+  connect_bd_net -net axi_hwicap_0_ip2intc_irpt [get_bd_pins axi_hwicap_0/ip2intc_irpt] [get_bd_pins microblaze_0_xlconcat/In7]
+  connect_bd_net -net axi_quad_spi_0_ip2intc_irpt [get_bd_pins axi_quad_spi_0/ip2intc_irpt] [get_bd_pins microblaze_0_xlconcat/In0]
+  connect_bd_net -net axi_timer_0_interrupt [get_bd_pins axi_timer_0/interrupt] [get_bd_pins microblaze_0_xlconcat/In6]
+  connect_bd_net -net axi_uart16550_0_ip2intc_irpt [get_bd_pins axi_uart16550_0/ip2intc_irpt] [get_bd_pins microblaze_0_xlconcat/In1]
+  connect_bd_net -net ddr4_0_addn_ui_clkout1 [get_bd_pins axi_bram_ctrl_0/s_axi_aclk] [get_bd_pins axi_ethernet_0/s_axi_lite_clk] [get_bd_pins axi_ethernet_0_dma/s_axi_lite_aclk] [get_bd_pins axi_hwicap_0/icap_clk] [get_bd_pins axi_hwicap_0/s_axi_aclk] [get_bd_pins axi_mem_intercon/ACLK] [get_bd_pins axi_mem_intercon/M00_ACLK] [get_bd_pins axi_mem_intercon/S00_ACLK] [get_bd_pins axi_mem_intercon/S01_ACLK] [get_bd_pins axi_quad_spi_0/s_axi_aclk] [get_bd_pins axi_timer_0/s_axi_aclk] [get_bd_pins axi_uart16550_0/s_axi_aclk] [get_bd_pins ddr4_0/addn_ui_clkout1] [get_bd_pins ila_3/clk] [get_bd_pins jtag_axi_0/aclk] [get_bd_pins microblaze_0/Clk] [get_bd_pins microblaze_0_axi_intc/processor_clk] [get_bd_pins microblaze_0_axi_intc/s_axi_aclk] [get_bd_pins microblaze_0_axi_periph/ACLK] [get_bd_pins microblaze_0_axi_periph/M00_ACLK] [get_bd_pins microblaze_0_axi_periph/M01_ACLK] [get_bd_pins microblaze_0_axi_periph/M02_ACLK] [get_bd_pins microblaze_0_axi_periph/M04_ACLK] [get_bd_pins microblaze_0_axi_periph/M05_ACLK] [get_bd_pins microblaze_0_axi_periph/M06_ACLK] [get_bd_pins microblaze_0_axi_periph/M07_ACLK] [get_bd_pins microblaze_0_axi_periph/M08_ACLK] [get_bd_pins microblaze_0_axi_periph/S00_ACLK] [get_bd_pins microblaze_0_axi_periph/S01_ACLK] [get_bd_pins microblaze_0_axi_periph/S02_ACLK] [get_bd_pins microblaze_0_local_memory/LMB_Clk] [get_bd_pins rst_ddr4_0_100M/slowest_sync_clk] [get_bd_pins system_ila_0/clk]
+  connect_bd_net -net ddr4_0_addn_ui_clkout2 [get_bd_pins axi_quad_spi_0/ext_spi_clk] [get_bd_pins ddr4_0/addn_ui_clkout2]
+  connect_bd_net -net ddr4_0_addn_ui_clkout3 [get_bd_ports addn_ui_clkout3_0] [get_bd_pins ddr4_0/addn_ui_clkout3]
+  connect_bd_net -net ddr4_0_c0_ddr4_ui_clk_sync_rst [get_bd_pins ddr4_0/c0_ddr4_ui_clk_sync_rst] [get_bd_pins rst_ddr4_0_100M/ext_reset_in] [get_bd_pins rst_ddr4_0_300M/ext_reset_in]
+  connect_bd_net -net ddr4_0_c0_init_calib_complete [get_bd_pins ddr4_0/c0_init_calib_complete] [get_bd_pins rst_ddr4_0_100M/dcm_locked] [get_bd_pins rst_ddr4_0_300M/dcm_locked]
+  connect_bd_net -net dummy_port_in_1 [get_bd_ports dummy_port_in] [get_bd_pins axi_ethernet_0/dummy_port_in]
+  connect_bd_net -net mdm_1_debug_sys_rst [get_bd_pins mdm_1/Debug_SYS_Rst] [get_bd_pins rst_ddr4_0_100M/mb_debug_sys_rst]
+  connect_bd_net -net microblaze_0_intr [get_bd_pins microblaze_0_axi_intc/intr] [get_bd_pins microblaze_0_xlconcat/dout]
+  connect_bd_net -net reset_1 [get_bd_ports reset] [get_bd_pins ddr4_0/sys_rst] [get_bd_pins rst_ddr4_0_100M/aux_reset_in] [get_bd_pins rst_ddr4_0_300M/aux_reset_in]
+  connect_bd_net -net rst_ddr4_0_100M_bus_struct_reset [get_bd_pins microblaze_0_local_memory/SYS_Rst] [get_bd_pins rst_ddr4_0_100M/bus_struct_reset]
+  connect_bd_net -net rst_ddr4_0_100M_interconnect_aresetn [get_bd_pins axi_mem_intercon/ARESETN] [get_bd_pins microblaze_0_axi_periph/ARESETN] [get_bd_pins rst_ddr4_0_100M/interconnect_aresetn]
+  connect_bd_net -net rst_ddr4_0_100M_mb_reset [get_bd_pins microblaze_0/Reset] [get_bd_pins microblaze_0_axi_intc/processor_rst] [get_bd_pins rst_ddr4_0_100M/mb_reset]
+  connect_bd_net -net rst_ddr4_0_100M_peripheral_aresetn [get_bd_pins axi_bram_ctrl_0/s_axi_aresetn] [get_bd_pins axi_ethernet_0/s_axi_lite_resetn] [get_bd_pins axi_ethernet_0_dma/axi_resetn] [get_bd_pins axi_hwicap_0/s_axi_aresetn] [get_bd_pins axi_mem_intercon/M00_ARESETN] [get_bd_pins axi_mem_intercon/S00_ARESETN] [get_bd_pins axi_mem_intercon/S01_ARESETN] [get_bd_pins axi_quad_spi_0/s_axi_aresetn] [get_bd_pins axi_timer_0/s_axi_aresetn] [get_bd_pins axi_uart16550_0/s_axi_aresetn] [get_bd_pins jtag_axi_0/aresetn] [get_bd_pins microblaze_0_axi_intc/s_axi_aresetn] [get_bd_pins microblaze_0_axi_periph/M00_ARESETN] [get_bd_pins microblaze_0_axi_periph/M01_ARESETN] [get_bd_pins microblaze_0_axi_periph/M02_ARESETN] [get_bd_pins microblaze_0_axi_periph/M04_ARESETN] [get_bd_pins microblaze_0_axi_periph/M05_ARESETN] [get_bd_pins microblaze_0_axi_periph/M06_ARESETN] [get_bd_pins microblaze_0_axi_periph/M07_ARESETN] [get_bd_pins microblaze_0_axi_periph/M08_ARESETN] [get_bd_pins microblaze_0_axi_periph/S00_ARESETN] [get_bd_pins microblaze_0_axi_periph/S01_ARESETN] [get_bd_pins microblaze_0_axi_periph/S02_ARESETN] [get_bd_pins rst_ddr4_0_100M/peripheral_aresetn] [get_bd_pins system_ila_0/resetn]
+  connect_bd_net -net rst_ddr4_0_300M_peripheral_aresetn [get_bd_pins axi_mem_intercon/M01_ARESETN] [get_bd_pins axi_mem_intercon/S02_ARESETN] [get_bd_pins axi_mem_intercon/S03_ARESETN] [get_bd_pins axi_mem_intercon/S04_ARESETN] [get_bd_pins ddr4_0/c0_ddr4_aresetn] [get_bd_pins microblaze_0_axi_periph/M03_ARESETN] [get_bd_pins rst_ddr4_0_300M/peripheral_aresetn]
+  connect_bd_net -net xlconstant_0_dout [get_bd_pins axi_hwicap_0/cap_rel] [get_bd_pins xlconstant_0/dout]
+  connect_bd_net -net xlconstant_1_dout [get_bd_pins axi_hwicap_0/cap_gnt] [get_bd_pins xlconstant_1/dout]
+
+  # Create address segments
+  create_bd_addr_seg -range 0x00400000 -offset 0xC0000000 [get_bd_addr_spaces axi_ethernet_0_dma/Data_SG] [get_bd_addr_segs axi_bram_ctrl_0/S_AXI/Mem0] SEG_axi_bram_ctrl_0_Mem0
+  create_bd_addr_seg -range 0x00400000 -offset 0xC0000000 [get_bd_addr_spaces axi_ethernet_0_dma/Data_MM2S] [get_bd_addr_segs axi_bram_ctrl_0/S_AXI/Mem0] SEG_axi_bram_ctrl_0_Mem0
+  create_bd_addr_seg -range 0x00400000 -offset 0xC0000000 [get_bd_addr_spaces axi_ethernet_0_dma/Data_S2MM] [get_bd_addr_segs axi_bram_ctrl_0/S_AXI/Mem0] SEG_axi_bram_ctrl_0_Mem0
+  create_bd_addr_seg -range 0x40000000 -offset 0x80000000 [get_bd_addr_spaces axi_ethernet_0_dma/Data_SG] [get_bd_addr_segs ddr4_0/C0_DDR4_MEMORY_MAP/C0_DDR4_ADDRESS_BLOCK] SEG_ddr4_0_C0_DDR4_ADDRESS_BLOCK
+  create_bd_addr_seg -range 0x40000000 -offset 0x80000000 [get_bd_addr_spaces axi_ethernet_0_dma/Data_MM2S] [get_bd_addr_segs ddr4_0/C0_DDR4_MEMORY_MAP/C0_DDR4_ADDRESS_BLOCK] SEG_ddr4_0_C0_DDR4_ADDRESS_BLOCK
+  create_bd_addr_seg -range 0x40000000 -offset 0x80000000 [get_bd_addr_spaces axi_ethernet_0_dma/Data_S2MM] [get_bd_addr_segs ddr4_0/C0_DDR4_MEMORY_MAP/C0_DDR4_ADDRESS_BLOCK] SEG_ddr4_0_C0_DDR4_ADDRESS_BLOCK
+  create_bd_addr_seg -range 0x00010000 -offset 0x40C00000 [get_bd_addr_spaces jtag_axi_0/Data] [get_bd_addr_segs axi_ethernet_0/s_axi/Reg0] SEG_axi_ethernet_0_Reg0
+  create_bd_addr_seg -range 0x00010000 -offset 0x41E00000 [get_bd_addr_spaces jtag_axi_0/Data] [get_bd_addr_segs axi_ethernet_0_dma/S_AXI_LITE/Reg] SEG_axi_ethernet_0_dma_Reg
+  create_bd_addr_seg -range 0x00010000 -offset 0x40200000 [get_bd_addr_spaces jtag_axi_0/Data] [get_bd_addr_segs axi_hwicap_0/S_AXI_LITE/Reg] SEG_axi_hwicap_0_Reg
+  create_bd_addr_seg -range 0x00010000 -offset 0x44A00000 [get_bd_addr_spaces jtag_axi_0/Data] [get_bd_addr_segs axi_quad_spi_0/AXI_LITE/Reg] SEG_axi_quad_spi_0_Reg
+  create_bd_addr_seg -range 0x00010000 -offset 0x41C00000 [get_bd_addr_spaces jtag_axi_0/Data] [get_bd_addr_segs axi_timer_0/S_AXI/Reg] SEG_axi_timer_0_Reg
+  create_bd_addr_seg -range 0x00010000 -offset 0x44A10000 [get_bd_addr_spaces jtag_axi_0/Data] [get_bd_addr_segs axi_uart16550_0/S_AXI/Reg] SEG_axi_uart16550_0_Reg
+  create_bd_addr_seg -range 0x00100000 -offset 0x70000000 [get_bd_addr_spaces jtag_axi_0/Data] [get_bd_addr_segs ddr4_0/C0_DDR4_MEMORY_MAP_CTRL/C0_REG] SEG_ddr4_0_C0_REG
+  create_bd_addr_seg -range 0x00010000 -offset 0x41200000 [get_bd_addr_spaces jtag_axi_0/Data] [get_bd_addr_segs microblaze_0_axi_intc/S_AXI/Reg] SEG_microblaze_0_axi_intc_Reg
+  create_bd_addr_seg -range 0x00400000 -offset 0xC0000000 [get_bd_addr_spaces microblaze_0/Data] [get_bd_addr_segs axi_bram_ctrl_0/S_AXI/Mem0] SEG_axi_bram_ctrl_0_Mem0
+  create_bd_addr_seg -range 0x00400000 -offset 0xC0000000 [get_bd_addr_spaces microblaze_0/Instruction] [get_bd_addr_segs axi_bram_ctrl_0/S_AXI/Mem0] SEG_axi_bram_ctrl_0_Mem0
+  create_bd_addr_seg -range 0x00010000 -offset 0x40C00000 [get_bd_addr_spaces microblaze_0/Data] [get_bd_addr_segs axi_ethernet_0/s_axi/Reg0] SEG_axi_ethernet_0_Reg0
+  create_bd_addr_seg -range 0x00010000 -offset 0x40C00000 [get_bd_addr_spaces microblaze_0/Instruction] [get_bd_addr_segs axi_ethernet_0/s_axi/Reg0] SEG_axi_ethernet_0_Reg0
+  create_bd_addr_seg -range 0x00010000 -offset 0x41E00000 [get_bd_addr_spaces microblaze_0/Data] [get_bd_addr_segs axi_ethernet_0_dma/S_AXI_LITE/Reg] SEG_axi_ethernet_0_dma_Reg
+  create_bd_addr_seg -range 0x00010000 -offset 0x41E00000 [get_bd_addr_spaces microblaze_0/Instruction] [get_bd_addr_segs axi_ethernet_0_dma/S_AXI_LITE/Reg] SEG_axi_ethernet_0_dma_Reg
+  create_bd_addr_seg -range 0x00010000 -offset 0x40200000 [get_bd_addr_spaces microblaze_0/Data] [get_bd_addr_segs axi_hwicap_0/S_AXI_LITE/Reg] SEG_axi_hwicap_0_Reg
+  create_bd_addr_seg -range 0x00010000 -offset 0x40200000 [get_bd_addr_spaces microblaze_0/Instruction] [get_bd_addr_segs axi_hwicap_0/S_AXI_LITE/Reg] SEG_axi_hwicap_0_Reg
+  create_bd_addr_seg -range 0x00010000 -offset 0x44A00000 [get_bd_addr_spaces microblaze_0/Data] [get_bd_addr_segs axi_quad_spi_0/AXI_LITE/Reg] SEG_axi_quad_spi_0_Reg
+  create_bd_addr_seg -range 0x00010000 -offset 0x44A00000 [get_bd_addr_spaces microblaze_0/Instruction] [get_bd_addr_segs axi_quad_spi_0/AXI_LITE/Reg] SEG_axi_quad_spi_0_Reg
+  create_bd_addr_seg -range 0x00010000 -offset 0x41C00000 [get_bd_addr_spaces microblaze_0/Data] [get_bd_addr_segs axi_timer_0/S_AXI/Reg] SEG_axi_timer_0_Reg
+  create_bd_addr_seg -range 0x00010000 -offset 0x41C00000 [get_bd_addr_spaces microblaze_0/Instruction] [get_bd_addr_segs axi_timer_0/S_AXI/Reg] SEG_axi_timer_0_Reg
+  create_bd_addr_seg -range 0x00010000 -offset 0x44A10000 [get_bd_addr_spaces microblaze_0/Data] [get_bd_addr_segs axi_uart16550_0/S_AXI/Reg] SEG_axi_uart16550_0_Reg
+  create_bd_addr_seg -range 0x00010000 -offset 0x44A10000 [get_bd_addr_spaces microblaze_0/Instruction] [get_bd_addr_segs axi_uart16550_0/S_AXI/Reg] SEG_axi_uart16550_0_Reg
+  create_bd_addr_seg -range 0x40000000 -offset 0x80000000 [get_bd_addr_spaces microblaze_0/Data] [get_bd_addr_segs ddr4_0/C0_DDR4_MEMORY_MAP/C0_DDR4_ADDRESS_BLOCK] SEG_ddr4_0_C0_DDR4_ADDRESS_BLOCK
+  create_bd_addr_seg -range 0x40000000 -offset 0x80000000 [get_bd_addr_spaces microblaze_0/Instruction] [get_bd_addr_segs ddr4_0/C0_DDR4_MEMORY_MAP/C0_DDR4_ADDRESS_BLOCK] SEG_ddr4_0_C0_DDR4_ADDRESS_BLOCK
+  create_bd_addr_seg -range 0x00100000 -offset 0x70000000 [get_bd_addr_spaces microblaze_0/Data] [get_bd_addr_segs ddr4_0/C0_DDR4_MEMORY_MAP_CTRL/C0_REG] SEG_ddr4_0_C0_REG
+  create_bd_addr_seg -range 0x00100000 -offset 0x70000000 [get_bd_addr_spaces microblaze_0/Instruction] [get_bd_addr_segs ddr4_0/C0_DDR4_MEMORY_MAP_CTRL/C0_REG] SEG_ddr4_0_C0_REG
+  create_bd_addr_seg -range 0x00100000 -offset 0x00000000 [get_bd_addr_spaces microblaze_0/Data] [get_bd_addr_segs microblaze_0_local_memory/dlmb_bram_if_cntlr/SLMB/Mem] SEG_dlmb_bram_if_cntlr_Mem
+  create_bd_addr_seg -range 0x00100000 -offset 0x00000000 [get_bd_addr_spaces microblaze_0/Instruction] [get_bd_addr_segs microblaze_0_local_memory/ilmb_bram_if_cntlr/SLMB/Mem] SEG_ilmb_bram_if_cntlr_Mem
+  create_bd_addr_seg -range 0x00010000 -offset 0x41200000 [get_bd_addr_spaces microblaze_0/Data] [get_bd_addr_segs microblaze_0_axi_intc/S_AXI/Reg] SEG_microblaze_0_axi_intc_Reg
+  create_bd_addr_seg -range 0x00010000 -offset 0x41200000 [get_bd_addr_spaces microblaze_0/Instruction] [get_bd_addr_segs microblaze_0_axi_intc/S_AXI/Reg] SEG_microblaze_0_axi_intc_Reg
+
+
+  # Restore current instance
+  current_bd_instance $oldCurInst
+
+  save_bd_design
+}
+
+
+# open_bd_design {./project/project.srcs/sources_1/bd/static_bd/static_bd.bd}
+
+# validate_bd_design 
+# set_property synth_checkpoint_mode None [get_files ./project/project.srcs/sources_1/bd/static_bd/static_bd.bd] 
+# generate_target all [get_files  ./project/project.srcs/sources_1/bd/static_bd/static_bd.bd]
+
+open_bd_design {C:/Users/HQ_home/Desktop/ICAP/xapp1292/xapp1292_v2019_1/example_3/project/project.srcs/sources_1/bd/static_bd/static_bd.bd}
+
+validate_bd_design 
+set_property synth_checkpoint_mode None [get_files C:/Users/HQ_home/Desktop/ICAP/xapp1292/xapp1292_v2019_1/example_3/project/project.srcs/sources_1/bd/static_bd/static_bd.bd] 
+generate_target -force all [get_files  C:/Users/HQ_home/Desktop/ICAP/xapp1292/xapp1292_v2019_1/example_3/project/project.srcs/sources_1/bd/static_bd/static_bd.bd]
+
+

--- a/xapp1292-loading-partial-bitstreams-using-tftp/example_3/design_0729.tcl
+++ b/xapp1292-loading-partial-bitstreams-using-tftp/example_3/design_0729.tcl
@@ -43,18 +43,14 @@ if { [string first $scripts_vivado_version $current_vivado_version] == -1 } {
 
 set list_projs [get_projects -quiet]
 if { $list_projs eq "" } {
-  #  2020-8-1 QiLe
-  #  create_project project_1 myproj -part xcvu37p-fsvh2892-2L-e
-   create_project project ./project -part xcvu37p-fsvh2892-2L-e -force
-
+   create_project project_1 myproj -part xcvu37p-fsvh2892-2L-e
    set_property BOARD_PART xilinx.com:vcu128:part0:1.0 [current_project]
 }
 
-# 2020-8-1 QiLe
-set_property target_language VHDL [current_project]
+
 # CHANGE DESIGN NAME HERE
 variable design_name
-set design_name static_bd
+set design_name design_1
 
 # If you do not already have an existing IP Integrator design open,
 # you can create a design using the following command:
@@ -145,7 +141,6 @@ xilinx.com:ip:axi_intc:4.1\
 xilinx.com:ip:xlconcat:2.1\
 xilinx.com:ip:proc_sys_reset:5.0\
 xilinx.com:ip:system_ila:1.1\
-xilinx.com:ip:xlconstant:1.1\
 xilinx.com:ip:lmb_bram_if_cntlr:4.0\
 xilinx.com:ip:lmb_v10:3.0\
 "
@@ -296,8 +291,6 @@ proc create_root_design { parentCell } {
 
 
   # Create interface ports
-  set ICAP_0 [ create_bd_intf_port -mode Master -vlnv xilinx.com:interface:icap_rtl:1.0 ICAP_0 ]
-
   set ddr4_sdram [ create_bd_intf_port -mode Master -vlnv xilinx.com:interface:ddr4_rtl:1.0 ddr4_sdram ]
 
   set default_100mhz_clk [ create_bd_intf_port -mode Slave -vlnv xilinx.com:interface:diff_clock_rtl:1.0 default_100mhz_clk ]
@@ -423,7 +416,6 @@ proc create_root_design { parentCell } {
   # Create instance: axi_hwicap_0, and set properties
   set axi_hwicap_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:axi_hwicap:3.0 axi_hwicap_0 ]
   set_property -dict [ list \
-   CONFIG.C_ICAP_EXTERNAL {1} \
    CONFIG.C_WRITE_FIFO_DEPTH {1024} \
  ] $axi_hwicap_0
 
@@ -561,15 +553,6 @@ proc create_root_design { parentCell } {
    CONFIG.C_SLOT_0_INTF_TYPE {xilinx.com:interface:aximm_rtl:1.0} \
  ] $system_ila_0
 
-  # Create instance: xlconstant_0, and set properties
-  set xlconstant_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:xlconstant:1.1 xlconstant_0 ]
-  set_property -dict [ list \
-   CONFIG.CONST_VAL {0} \
- ] $xlconstant_0
-
-  # Create instance: xlconstant_1, and set properties
-  set xlconstant_1 [ create_bd_cell -type ip -vlnv xilinx.com:ip:xlconstant:1.1 xlconstant_1 ]
-
   # Create interface connections
   connect_bd_intf_net -intf_net axi_bram_ctrl_0_BRAM_PORTA [get_bd_intf_pins axi_bram_ctrl_0/BRAM_PORTA] [get_bd_intf_pins axi_bram_ctrl_0_bram/BRAM_PORTA]
   connect_bd_intf_net -intf_net axi_bram_ctrl_0_BRAM_PORTB [get_bd_intf_pins axi_bram_ctrl_0/BRAM_PORTB] [get_bd_intf_pins axi_bram_ctrl_0_bram/BRAM_PORTB]
@@ -582,7 +565,6 @@ proc create_root_design { parentCell } {
   connect_bd_intf_net -intf_net axi_ethernet_0_m_axis_rxs [get_bd_intf_pins axi_ethernet_0/m_axis_rxs] [get_bd_intf_pins axi_ethernet_0_dma/S_AXIS_STS]
   connect_bd_intf_net -intf_net axi_ethernet_0_mdio [get_bd_intf_ports mdio_mdc] [get_bd_intf_pins axi_ethernet_0/mdio]
   connect_bd_intf_net -intf_net axi_ethernet_0_sgmii [get_bd_intf_ports sgmii_lvds] [get_bd_intf_pins axi_ethernet_0/sgmii]
-  connect_bd_intf_net -intf_net axi_hwicap_0_ICAP [get_bd_intf_ports ICAP_0] [get_bd_intf_pins axi_hwicap_0/ICAP]
   connect_bd_intf_net -intf_net axi_mem_intercon_M00_AXI [get_bd_intf_pins axi_bram_ctrl_0/S_AXI] [get_bd_intf_pins axi_mem_intercon/M00_AXI]
   connect_bd_intf_net -intf_net axi_mem_intercon_M01_AXI [get_bd_intf_pins axi_mem_intercon/M01_AXI] [get_bd_intf_pins ddr4_0/C0_DDR4_S_AXI]
   connect_bd_intf_net -intf_net axi_uart16550_0_UART [get_bd_intf_ports rs232_uart_0] [get_bd_intf_pins axi_uart16550_0/UART]
@@ -638,8 +620,6 @@ connect_bd_intf_net -intf_net [get_bd_intf_nets microblaze_0_axi_periph_M08_AXI]
   connect_bd_net -net rst_ddr4_0_100M_mb_reset [get_bd_pins microblaze_0/Reset] [get_bd_pins microblaze_0_axi_intc/processor_rst] [get_bd_pins rst_ddr4_0_100M/mb_reset]
   connect_bd_net -net rst_ddr4_0_100M_peripheral_aresetn [get_bd_pins axi_bram_ctrl_0/s_axi_aresetn] [get_bd_pins axi_ethernet_0/s_axi_lite_resetn] [get_bd_pins axi_ethernet_0_dma/axi_resetn] [get_bd_pins axi_hwicap_0/s_axi_aresetn] [get_bd_pins axi_mem_intercon/M00_ARESETN] [get_bd_pins axi_mem_intercon/S00_ARESETN] [get_bd_pins axi_mem_intercon/S01_ARESETN] [get_bd_pins axi_quad_spi_0/s_axi_aresetn] [get_bd_pins axi_timer_0/s_axi_aresetn] [get_bd_pins axi_uart16550_0/s_axi_aresetn] [get_bd_pins jtag_axi_0/aresetn] [get_bd_pins microblaze_0_axi_intc/s_axi_aresetn] [get_bd_pins microblaze_0_axi_periph/M00_ARESETN] [get_bd_pins microblaze_0_axi_periph/M01_ARESETN] [get_bd_pins microblaze_0_axi_periph/M02_ARESETN] [get_bd_pins microblaze_0_axi_periph/M04_ARESETN] [get_bd_pins microblaze_0_axi_periph/M05_ARESETN] [get_bd_pins microblaze_0_axi_periph/M06_ARESETN] [get_bd_pins microblaze_0_axi_periph/M07_ARESETN] [get_bd_pins microblaze_0_axi_periph/M08_ARESETN] [get_bd_pins microblaze_0_axi_periph/S00_ARESETN] [get_bd_pins microblaze_0_axi_periph/S01_ARESETN] [get_bd_pins microblaze_0_axi_periph/S02_ARESETN] [get_bd_pins rst_ddr4_0_100M/peripheral_aresetn] [get_bd_pins system_ila_0/resetn]
   connect_bd_net -net rst_ddr4_0_300M_peripheral_aresetn [get_bd_pins axi_mem_intercon/M01_ARESETN] [get_bd_pins axi_mem_intercon/S02_ARESETN] [get_bd_pins axi_mem_intercon/S03_ARESETN] [get_bd_pins axi_mem_intercon/S04_ARESETN] [get_bd_pins ddr4_0/c0_ddr4_aresetn] [get_bd_pins microblaze_0_axi_periph/M03_ARESETN] [get_bd_pins rst_ddr4_0_300M/peripheral_aresetn]
-  connect_bd_net -net xlconstant_0_dout [get_bd_pins axi_hwicap_0/cap_rel] [get_bd_pins xlconstant_0/dout]
-  connect_bd_net -net xlconstant_1_dout [get_bd_pins axi_hwicap_0/cap_gnt] [get_bd_pins xlconstant_1/dout]
 
   # Create address segments
   create_bd_addr_seg -range 0x00400000 -offset 0xC0000000 [get_bd_addr_spaces axi_ethernet_0_dma/Data_SG] [get_bd_addr_segs axi_bram_ctrl_0/S_AXI/Mem0] SEG_axi_bram_ctrl_0_Mem0
@@ -674,8 +654,8 @@ connect_bd_intf_net -intf_net [get_bd_intf_nets microblaze_0_axi_periph_M08_AXI]
   create_bd_addr_seg -range 0x40000000 -offset 0x80000000 [get_bd_addr_spaces microblaze_0/Instruction] [get_bd_addr_segs ddr4_0/C0_DDR4_MEMORY_MAP/C0_DDR4_ADDRESS_BLOCK] SEG_ddr4_0_C0_DDR4_ADDRESS_BLOCK
   create_bd_addr_seg -range 0x00100000 -offset 0x70000000 [get_bd_addr_spaces microblaze_0/Data] [get_bd_addr_segs ddr4_0/C0_DDR4_MEMORY_MAP_CTRL/C0_REG] SEG_ddr4_0_C0_REG
   create_bd_addr_seg -range 0x00100000 -offset 0x70000000 [get_bd_addr_spaces microblaze_0/Instruction] [get_bd_addr_segs ddr4_0/C0_DDR4_MEMORY_MAP_CTRL/C0_REG] SEG_ddr4_0_C0_REG
-  create_bd_addr_seg -range 0x00100000 -offset 0x00000000 [get_bd_addr_spaces microblaze_0/Data] [get_bd_addr_segs microblaze_0_local_memory/dlmb_bram_if_cntlr/SLMB/Mem] SEG_dlmb_bram_if_cntlr_Mem
-  create_bd_addr_seg -range 0x00100000 -offset 0x00000000 [get_bd_addr_spaces microblaze_0/Instruction] [get_bd_addr_segs microblaze_0_local_memory/ilmb_bram_if_cntlr/SLMB/Mem] SEG_ilmb_bram_if_cntlr_Mem
+  create_bd_addr_seg -range 0x00080000 -offset 0x00000000 [get_bd_addr_spaces microblaze_0/Data] [get_bd_addr_segs microblaze_0_local_memory/dlmb_bram_if_cntlr/SLMB/Mem] SEG_dlmb_bram_if_cntlr_Mem
+  create_bd_addr_seg -range 0x00080000 -offset 0x00000000 [get_bd_addr_spaces microblaze_0/Instruction] [get_bd_addr_segs microblaze_0_local_memory/ilmb_bram_if_cntlr/SLMB/Mem] SEG_ilmb_bram_if_cntlr_Mem
   create_bd_addr_seg -range 0x00010000 -offset 0x41200000 [get_bd_addr_spaces microblaze_0/Data] [get_bd_addr_segs microblaze_0_axi_intc/S_AXI/Reg] SEG_microblaze_0_axi_intc_Reg
   create_bd_addr_seg -range 0x00010000 -offset 0x41200000 [get_bd_addr_spaces microblaze_0/Instruction] [get_bd_addr_segs microblaze_0_axi_intc/S_AXI/Reg] SEG_microblaze_0_axi_intc_Reg
 
@@ -683,6 +663,7 @@ connect_bd_intf_net -intf_net [get_bd_intf_nets microblaze_0_axi_periph_M08_AXI]
   # Restore current instance
   current_bd_instance $oldCurInst
 
+  validate_bd_design
   save_bd_design
 }
 # End of create_root_design()
@@ -695,11 +676,3 @@ connect_bd_intf_net -intf_net [get_bd_intf_nets microblaze_0_axi_periph_M08_AXI]
 create_root_design ""
 
 
-common::send_msg_id "BD_TCL-1000" "WARNING" "This Tcl script was generated from a block design that has not been validated. It is possible that design <$design_name> may result in errors during validation."
-
-# 2020-8-1 QiLe
-open_bd_design {./project/project.srcs/sources_1/bd/static_bd/static_bd.bd}
-
-validate_bd_design 
-set_property synth_checkpoint_mode None [get_files ./project/project.srcs/sources_1/bd/static_bd/static_bd.bd] 
-generate_target all [get_files  ./project/project.srcs/sources_1/bd/static_bd/static_bd.bd]

--- a/xapp1292-loading-partial-bitstreams-using-tftp/example_3/design_0731.tcl
+++ b/xapp1292-loading-partial-bitstreams-using-tftp/example_3/design_0731.tcl
@@ -43,18 +43,14 @@ if { [string first $scripts_vivado_version $current_vivado_version] == -1 } {
 
 set list_projs [get_projects -quiet]
 if { $list_projs eq "" } {
-  #  2020-8-1 QiLe
-  #  create_project project_1 myproj -part xcvu37p-fsvh2892-2L-e
-   create_project project ./project -part xcvu37p-fsvh2892-2L-e -force
-
+   create_project project_1 myproj -part xcvu37p-fsvh2892-2L-e
    set_property BOARD_PART xilinx.com:vcu128:part0:1.0 [current_project]
 }
 
-# 2020-8-1 QiLe
-set_property target_language VHDL [current_project]
+
 # CHANGE DESIGN NAME HERE
 variable design_name
-set design_name static_bd
+set design_name design_1
 
 # If you do not already have an existing IP Integrator design open,
 # you can create a design using the following command:
@@ -697,9 +693,3 @@ create_root_design ""
 
 common::send_msg_id "BD_TCL-1000" "WARNING" "This Tcl script was generated from a block design that has not been validated. It is possible that design <$design_name> may result in errors during validation."
 
-# 2020-8-1 QiLe
-open_bd_design {./project/project.srcs/sources_1/bd/static_bd/static_bd.bd}
-
-validate_bd_design 
-set_property synth_checkpoint_mode None [get_files ./project/project.srcs/sources_1/bd/static_bd/static_bd.bd] 
-generate_target all [get_files  ./project/project.srcs/sources_1/bd/static_bd/static_bd.bd]

--- a/xapp1292-loading-partial-bitstreams-using-tftp/example_3/design_1_wrapper.vhd
+++ b/xapp1292-loading-partial-bitstreams-using-tftp/example_3/design_1_wrapper.vhd
@@ -1,0 +1,152 @@
+--Copyright 1986-2019 Xilinx, Inc. All Rights Reserved.
+----------------------------------------------------------------------------------
+--Tool Version: Vivado v.2019.1 (win64) Build 2552052 Fri May 24 14:49:42 MDT 2019
+--Date        : Fri Jul 31 18:50:19 2020
+--Host        : DESKTOP-0HGFOUP running 64-bit major release  (build 9200)
+--Command     : generate_target design_1_wrapper.bd
+--Design      : design_1_wrapper
+--Purpose     : IP block netlist
+----------------------------------------------------------------------------------
+library IEEE;
+use IEEE.STD_LOGIC_1164.ALL;
+library UNISIM;
+use UNISIM.VCOMPONENTS.ALL;
+entity design_1_wrapper is
+  port (
+    ICAP_0_avail : in STD_LOGIC;
+    ICAP_0_csib : out STD_LOGIC;
+    ICAP_0_i : out STD_LOGIC_VECTOR ( 31 downto 0 );
+    ICAP_0_o : in STD_LOGIC_VECTOR ( 31 downto 0 );
+    ICAP_0_rdwrb : out STD_LOGIC;
+    addn_ui_clkout3_0 : out STD_LOGIC;
+    ddr4_sdram_act_n : out STD_LOGIC;
+    ddr4_sdram_adr : out STD_LOGIC_VECTOR ( 16 downto 0 );
+    ddr4_sdram_ba : out STD_LOGIC_VECTOR ( 1 downto 0 );
+    ddr4_sdram_bg : out STD_LOGIC;
+    ddr4_sdram_ck_c : out STD_LOGIC;
+    ddr4_sdram_ck_t : out STD_LOGIC;
+    ddr4_sdram_cke : out STD_LOGIC;
+    ddr4_sdram_cs_n : out STD_LOGIC_VECTOR ( 1 downto 0 );
+    ddr4_sdram_dm_n : inout STD_LOGIC_VECTOR ( 8 downto 0 );
+    ddr4_sdram_dq : inout STD_LOGIC_VECTOR ( 71 downto 0 );
+    ddr4_sdram_dqs_c : inout STD_LOGIC_VECTOR ( 8 downto 0 );
+    ddr4_sdram_dqs_t : inout STD_LOGIC_VECTOR ( 8 downto 0 );
+    ddr4_sdram_odt : out STD_LOGIC;
+    ddr4_sdram_reset_n : out STD_LOGIC;
+    default_100mhz_clk_clk_n : in STD_LOGIC;
+    default_100mhz_clk_clk_p : in STD_LOGIC;
+    dummy_port_in : in STD_LOGIC;
+    mdio_mdc_mdc : out STD_LOGIC;
+    mdio_mdc_mdio_io : inout STD_LOGIC;
+    reset : in STD_LOGIC;
+    rs232_uart_0_rxd : in STD_LOGIC;
+    rs232_uart_0_txd : out STD_LOGIC;
+    sgmii_lvds_rxn : in STD_LOGIC;
+    sgmii_lvds_rxp : in STD_LOGIC;
+    sgmii_lvds_txn : out STD_LOGIC;
+    sgmii_lvds_txp : out STD_LOGIC;
+    sgmii_phyclk_clk_n : in STD_LOGIC;
+    sgmii_phyclk_clk_p : in STD_LOGIC
+  );
+end design_1_wrapper;
+
+architecture STRUCTURE of design_1_wrapper is
+  component design_1 is
+  port (
+    addn_ui_clkout3_0 : out STD_LOGIC;
+    dummy_port_in : in STD_LOGIC;
+    reset : in STD_LOGIC;
+    mdio_mdc_mdc : out STD_LOGIC;
+    mdio_mdc_mdio_i : in STD_LOGIC;
+    mdio_mdc_mdio_o : out STD_LOGIC;
+    mdio_mdc_mdio_t : out STD_LOGIC;
+    sgmii_lvds_rxn : in STD_LOGIC;
+    sgmii_lvds_rxp : in STD_LOGIC;
+    sgmii_lvds_txn : out STD_LOGIC;
+    sgmii_lvds_txp : out STD_LOGIC;
+    ICAP_0_avail : in STD_LOGIC;
+    ICAP_0_csib : out STD_LOGIC;
+    ICAP_0_i : out STD_LOGIC_VECTOR ( 31 downto 0 );
+    ICAP_0_o : in STD_LOGIC_VECTOR ( 31 downto 0 );
+    ICAP_0_rdwrb : out STD_LOGIC;
+    rs232_uart_0_rxd : in STD_LOGIC;
+    rs232_uart_0_txd : out STD_LOGIC;
+    ddr4_sdram_act_n : out STD_LOGIC;
+    ddr4_sdram_adr : out STD_LOGIC_VECTOR ( 16 downto 0 );
+    ddr4_sdram_ba : out STD_LOGIC_VECTOR ( 1 downto 0 );
+    ddr4_sdram_bg : out STD_LOGIC;
+    ddr4_sdram_ck_c : out STD_LOGIC;
+    ddr4_sdram_ck_t : out STD_LOGIC;
+    ddr4_sdram_cke : out STD_LOGIC;
+    ddr4_sdram_cs_n : out STD_LOGIC_VECTOR ( 1 downto 0 );
+    ddr4_sdram_dm_n : inout STD_LOGIC_VECTOR ( 8 downto 0 );
+    ddr4_sdram_dq : inout STD_LOGIC_VECTOR ( 71 downto 0 );
+    ddr4_sdram_dqs_c : inout STD_LOGIC_VECTOR ( 8 downto 0 );
+    ddr4_sdram_dqs_t : inout STD_LOGIC_VECTOR ( 8 downto 0 );
+    ddr4_sdram_odt : out STD_LOGIC;
+    ddr4_sdram_reset_n : out STD_LOGIC;
+    default_100mhz_clk_clk_n : in STD_LOGIC;
+    default_100mhz_clk_clk_p : in STD_LOGIC;
+    sgmii_phyclk_clk_n : in STD_LOGIC;
+    sgmii_phyclk_clk_p : in STD_LOGIC
+  );
+  end component design_1;
+  component IOBUF is
+  port (
+    I : in STD_LOGIC;
+    O : out STD_LOGIC;
+    T : in STD_LOGIC;
+    IO : inout STD_LOGIC
+  );
+  end component IOBUF;
+  signal mdio_mdc_mdio_i : STD_LOGIC;
+  signal mdio_mdc_mdio_o : STD_LOGIC;
+  signal mdio_mdc_mdio_t : STD_LOGIC;
+begin
+design_1_i: component design_1
+     port map (
+      ICAP_0_avail => ICAP_0_avail,
+      ICAP_0_csib => ICAP_0_csib,
+      ICAP_0_i(31 downto 0) => ICAP_0_i(31 downto 0),
+      ICAP_0_o(31 downto 0) => ICAP_0_o(31 downto 0),
+      ICAP_0_rdwrb => ICAP_0_rdwrb,
+      addn_ui_clkout3_0 => addn_ui_clkout3_0,
+      ddr4_sdram_act_n => ddr4_sdram_act_n,
+      ddr4_sdram_adr(16 downto 0) => ddr4_sdram_adr(16 downto 0),
+      ddr4_sdram_ba(1 downto 0) => ddr4_sdram_ba(1 downto 0),
+      ddr4_sdram_bg => ddr4_sdram_bg,
+      ddr4_sdram_ck_c => ddr4_sdram_ck_c,
+      ddr4_sdram_ck_t => ddr4_sdram_ck_t,
+      ddr4_sdram_cke => ddr4_sdram_cke,
+      ddr4_sdram_cs_n(1 downto 0) => ddr4_sdram_cs_n(1 downto 0),
+      ddr4_sdram_dm_n(8 downto 0) => ddr4_sdram_dm_n(8 downto 0),
+      ddr4_sdram_dq(71 downto 0) => ddr4_sdram_dq(71 downto 0),
+      ddr4_sdram_dqs_c(8 downto 0) => ddr4_sdram_dqs_c(8 downto 0),
+      ddr4_sdram_dqs_t(8 downto 0) => ddr4_sdram_dqs_t(8 downto 0),
+      ddr4_sdram_odt => ddr4_sdram_odt,
+      ddr4_sdram_reset_n => ddr4_sdram_reset_n,
+      default_100mhz_clk_clk_n => default_100mhz_clk_clk_n,
+      default_100mhz_clk_clk_p => default_100mhz_clk_clk_p,
+      dummy_port_in => dummy_port_in,
+      mdio_mdc_mdc => mdio_mdc_mdc,
+      mdio_mdc_mdio_i => mdio_mdc_mdio_i,
+      mdio_mdc_mdio_o => mdio_mdc_mdio_o,
+      mdio_mdc_mdio_t => mdio_mdc_mdio_t,
+      reset => reset,
+      rs232_uart_0_rxd => rs232_uart_0_rxd,
+      rs232_uart_0_txd => rs232_uart_0_txd,
+      sgmii_lvds_rxn => sgmii_lvds_rxn,
+      sgmii_lvds_rxp => sgmii_lvds_rxp,
+      sgmii_lvds_txn => sgmii_lvds_txn,
+      sgmii_lvds_txp => sgmii_lvds_txp,
+      sgmii_phyclk_clk_n => sgmii_phyclk_clk_n,
+      sgmii_phyclk_clk_p => sgmii_phyclk_clk_p
+    );
+mdio_mdc_mdio_iobuf: component IOBUF
+     port map (
+      I => mdio_mdc_mdio_o,
+      IO => mdio_mdc_mdio_io,
+      O => mdio_mdc_mdio_i,
+      T => mdio_mdc_mdio_t
+    );
+end STRUCTURE;

--- a/xapp1292-loading-partial-bitstreams-using-tftp/example_3/setup_pr_design.tcl
+++ b/xapp1292-loading-partial-bitstreams-using-tftp/example_3/setup_pr_design.tcl
@@ -49,7 +49,7 @@ set_attribute module $static vlog          [list    \
                                             ]
 set_attribute module $static vhdl          [list                                  \
                                             Sources/hdl/top/top.vhd       work    \
-                                            project/project.srcs/sources_1/bd/static_bd/hdl/static_bd.vhd work \
+                                            project/project.srcs/sources_1/bd/static_bd/synth/static_bd.vhd work \
                                             project/project.srcs/sources_1/bd/static_bd/hdl/static_bd_wrapper.vhd work \
                                             ]
 


### PR DESCRIPTION
This is a transplantation project based on VIVADO2019.1, modified the .tcl script collection, the corresponding top-level VHDL and xdc source files

Now the tcl script collection of xapp1292 has been modified, it can be synthesized normally and generate bitstream

But there are still two errors:
1. Although the project is changed to the device model of vu37p and the VCU128 board is selected, it will prompt that it does not match the SSIT device when downloading .bit

2. An error occurred when exporting the hardware to the SDK. The official explanation given by Xilinx is that this happens when there is no warpper outside of Blockdesign, but the actual process does not lack the step of generating a warpper.